### PR TITLE
Fix AttributeError when nix-build fails

### DIFF
--- a/mach_nix/run.py
+++ b/mach_nix/run.py
@@ -25,7 +25,6 @@ def gen(args, return_expr=False):
           f' --arg prefer_nixpkgs {json.dumps((not args.prefer_new))}'
     proc = sp.run(cmd, shell=True, stdout=sys.stderr)
     if proc.returncode:
-        print(proc.stderr.decode(), file=sys.stderr)
         exit(1)
     with open(f"{o_file}/share/mach_nix_file.nix") as src:
         expr = src.read()


### PR DESCRIPTION
Since commit fa2bb2d33fb9b9dc3113046e4fcc16088f56981a, the nix-build
subprocess is called without `capture_output=True`. Therefore, proc.stderr
is None. The subprocess stderr is already being dumped to stderr, so
there is no need for doing a print.