### PR TITLE
chore: package as nix flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,9 @@
+{
+  pkgs ? import (import ./mach_nix/nix/nixpkgs-src.nix) { config = {}; overlays = []; },
+  ...
+}:
 with builtins;
 let
-  pkgs = import (import ./mach_nix/nix/nixpkgs-src.nix) { config = {}; overlays = []; };
   python = import ./mach_nix/nix/python.nix { inherit pkgs; };
   python_deps = (builtins.attrValues (import ./mach_nix/nix/python-deps.nix { inherit python; fetchurl = pkgs.fetchurl; }));
   mergeOverrides = with pkgs.lib; foldr composeExtensions (self: super: { });

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,18 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1595053634,
-        "narHash": "sha256-VPjtXgkWiol/h5DDkB0c9K2llKfP0OgdtFoSFUDyf3M=",
+        "lastModified": 1601171649,
+        "narHash": "sha256-G3RUAi2DUq6r3ntASLS+LZC/Eamot55W1+xmBOgEh3M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "26a014166d216127cf79f045c416dd7eaedfae26",
+        "rev": "84d74ae9c9cbed73274b8e4e00be14688ffc93fe",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1594123299,
+        "narHash": "sha256-zxjtMmOV93pIVG242RpEXu14w/13XYDo3ygMoRIJg4c=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "590d6d1badea1956a31480a0cba1d8d029cf45d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1595053634,
+        "narHash": "sha256-VPjtXgkWiol/h5DDkB0c9K2llKfP0OgdtFoSFUDyf3M=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "26a014166d216127cf79f045c416dd7eaedfae26",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+
+    description = "Create highly reproducible python environments";
+
+    inputs.flake-utils.url = "github:numtide/flake-utils";
+
+    outputs = { self, nixpkgs, flake-utils }: {
+
+        packages.mach-nix = import ./default.nix;
+
+        defaultPackage = self.packages.mach-nix.mach-nix;
+
+        apps.mach-nix = flake-utils.lib.mkApp { drv = self.packages.mach-nix.mach-nix; };
+        defaultApp = self.apps.mach-nix;
+
+        mkPython = self.packages.mach-nix.mkPython;
+        mkPythonShell = self.packages.mach-nix.mkPythonShell;
+        
+    };
+}
+

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  inputs.nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:


### PR DESCRIPTION
1. `nix-env -iA nixpkgs.nixFlakes`
2. 
```console
$ cat ~/.config/nix/nix.conf
experimental-features = nix-command flakes
```
3. `nix shell --show-trace`

<details>

```console
$ nix shell --show-trace
while evaluating the attribute 'packages.mach-nix.mach-nix' at /nix/store/g75adbd9wjxcvlm7mxykc135jz7cljz0-source/default.nix:21:3:
while evaluating anonymous function at /nix/store/g75adbd9wjxcvlm7mxykc135jz7cljz0-source/mach_nix/nix/python.nix:1:1, called from /nix/store/g75adbd9wjxcvlm7mxykc135jz7cljz0-source/default.nix:3:12:
while evaluating anonymous function at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/impure.nix:15:1, called from /nix/store/g75adbd9wjxcvlm7mxykc135jz7cljz0-source/default.nix:2:10:
while evaluating anonymous function at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/default.nix:20:1, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/impure.nix:84:1:
while evaluating anonymous function at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:42:1, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/default.nix:123:10:
while evaluating 'dfold' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:60:27, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:136:4:
while evaluating 'go' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:63:18, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:72:13:
while evaluating 'imap1' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/lists.nix:116:14, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:78:30:
while evaluating 'reverseList' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/lists.nix:393:17, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/booter.nix:85:6:
while evaluating anonymous function at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/stdenv/default.nix:7:1, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/default.nix:119:12:
while evaluating 'elaborate' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/default.nix:17:15, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/default.nix:60:17:
while evaluating 'foldl' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/lists.nix:80:20, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/default.nix:127:13:
while evaluating 'foldl'' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/lists.nix:82:16, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/lists.nix:86:8:
while evaluating the attribute 'parsed.abi.assertions' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/default.nix:22:7:
while evaluating 'mkSystemFromString' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/parse.nix:440:24, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/default.nix:22:16:
while evaluating 'mkSkeletonFromList' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/parse.nix:367:24, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/parse.nix:440:49:
while evaluating 'splitString' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/strings.nix:382:23, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/systems/parse.nix:440:69:
while evaluating 'recurse' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/strings.nix:392:24, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/strings.nix:403:7:
while evaluating 'addContextFrom' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/strings.nix:369:23, called from /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/lib/strings.nix:385:11:
while evaluating the attribute 'system' at /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/impure.nix:90:30:

error: --- EvalError --------------------------------------------------------------------------------------- nix
in file: /nix/store/q04pywh9qywl1dxwdvsywmssasrhlv4d-nixpkgs/pkgs/top-level/impure.nix (90:39)

attribute 'currentSystem' missing
```

</details>

While trying to wrap my head arround the emerging error, I din't find the root couse.
Nevertheless, I thought, this might be some hands on kowledge sharing on [nix flakes](https://github.com/tweag/rfcs/blob/flakes/rfcs/0049-flakes.md).
See also: https://www.tweag.io/blog/2020-05-25-flakes/