### PR TITLE
Release 2.1.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+# 2.1.1 (30 Jul 2020)
+Fix broken wheel packages
+### Fixes:
+ - Some wheel packages could brake through patchelf if they already contained stripped binaries. Packages like numpy wouldn't work because of this. This is now fixed by passing `dontStrip` to the `autoPatchelf` routine.
+
 # 2.1.0 (04 Jul 2020)
 Bug fixes + new feature **buildPythonPackage** / **buildPythonApplication**
 ### Fixes:

--- a/Readme.md
+++ b/Readme.md
@@ -55,11 +55,11 @@ Table of Contents
 You can either install mach-nix via pip or by using nix in case you already have the nix package manager installed.
 #### Installing via pip
 ```shell
-pip install git+git://github.com/DavHau/mach-nix@2.1.0
+pip install git+git://github.com/DavHau/mach-nix@2.1.1
 ```
 #### Installing via nix
 ```shell
-nix-env -if https://github.com/DavHau/mach-nix/tarball/2.1.0 -A mach-nix
+nix-env -if https://github.com/DavHau/mach-nix/tarball/2.1.1 -A mach-nix
 ```
 
 ---
@@ -91,7 +91,7 @@ You can call mach-nix directly from a nix expression
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in
 mach-nix.mkPython {
@@ -131,7 +131,7 @@ Mach-nix can be fine tuned with additional arguments by importing it via `builti
 #### Configure Providers
 **Providers** allow you to configure the origin for your packages on a granular basis.
 
-The following 3 providers are available in version 2.1.0:
+The following 3 providers are available since version 2.0.0:
   1. **nixpkgs**: Provides packages directly from nixpkgs without modifying their sources. Has only a few versions available, but has a high success rate and all the nix features, like `cudaSupport` for tensorflow for example.
   2. **sdist**: Provides all package versions available from pypi which support setuptools and builds them via nixpkgs overlays wherever possible to resolve external dependencies. It still supports the nixpkgs specific features no matter which package version is selected. But chances are higher for a build to fail than with the **nixpkgs** provider.
   3. **wheel**: Provides all linux compatible wheel releases from pypi. Wheels can contain binaries. Mach-nix autopatches them to work on nix. Wheels are super quick to install and work quite reliable. Therefore this provider is preferred by default.

--- a/examples.md
+++ b/examples.md
@@ -24,7 +24,7 @@ build a python environment from a list of requirements
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in mach-nix.mkPython {
   requirements = builtins.readFile ./requirements.txt;
@@ -37,7 +37,7 @@ Build a python package from its source code and a list of requirements
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in mach-nix.buildPythonPackage {
   pname = "my-package";
@@ -53,7 +53,7 @@ Build a python package from its source code and a list of requirements
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in mach-nix.buildPythonPackage rec {
   pname = "projectname";
@@ -77,7 +77,7 @@ I have a complex set of requirements including tensorflow. I'd like to have tens
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in mach-nix.mkPython {
 
@@ -100,7 +100,7 @@ I'd like to install a more recent version of tensorflow which is not available f
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in mach-nix.mkPython {
 
@@ -129,7 +129,7 @@ I'd like to use a recent version of Pytorch from wheel, but I'd like to build th
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 overlays = []; # some very useful overlays
 in mach-nix.mkPython rec {
@@ -164,7 +164,7 @@ I have a complex requirements.txt which includes `imagecodecs`. It is available 
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "2.1.0";
+    ref = "2.1.1";
   });
 in mach-nix.mkPython rec {
 

--- a/mach_nix/generate.py
+++ b/mach_nix/generate.py
@@ -3,7 +3,7 @@ import sys
 
 from mach_nix.data.nixpkgs import NixpkgsDirectory
 from mach_nix.data.providers import CombinedDependencyProvider, ProviderSettings
-from mach_nix.generators.overlay_generator import OverlaysGenerator
+from mach_nix.generators.overides_generator import OverridesGenerator
 from mach_nix.requirements import parse_reqs, filter_reqs_by_eval_marker, context
 from mach_nix.resolver.resolvelib_resolver import ResolvelibResolver
 from mach_nix.versions import PyVer
@@ -36,7 +36,7 @@ def main():
         pypi_deps_db_src=pypi_deps_db_src,
         py_ver=py_ver
     )
-    generator = OverlaysGenerator(
+    generator = OverridesGenerator(
         py_ver,
         nixpkgs,
         pypi_fetcher_commit,

--- a/mach_nix/generators/overides_generator.py
+++ b/mach_nix/generators/overides_generator.py
@@ -1,6 +1,6 @@
 from typing import Dict, List
 
-from data.providers import WheelDependencyProvider, SdistDependencyProvider, NixpkgsDependencyProvider
+from mach_nix.data.providers import WheelDependencyProvider, SdistDependencyProvider, NixpkgsDependencyProvider
 from mach_nix.data.nixpkgs import NixpkgsDirectory
 from mach_nix.generators import ExpressionGenerator
 from mach_nix.resolver import ResolvedPkg
@@ -12,7 +12,7 @@ def unindent(text: str, remove: int):
     return ''.join(map(lambda l: l[remove:], text.splitlines(keepends=True)))
 
 
-class OverlaysGenerator(ExpressionGenerator):
+class OverridesGenerator(ExpressionGenerator):
 
     def __init__(self, py_ver, nixpkgs: NixpkgsDirectory, pypi_fetcher_commit,
                  pypi_fetcher_sha256, disable_checks,
@@ -23,7 +23,7 @@ class OverlaysGenerator(ExpressionGenerator):
         self.pypi_fetcher_commit = pypi_fetcher_commit
         self.pypi_fetcher_sha256 = pypi_fetcher_sha256
         self.py_ver_nix = py_ver.nix()
-        super(OverlaysGenerator, self).__init__(*args, **kwargs)
+        super(OverridesGenerator, self).__init__(*args, **kwargs)
 
     def generate(self, reqs) -> str:
         pkgs = self.resolver.resolve(reqs)


### PR DESCRIPTION
# 2.1.1 (30 Jul 2020)
Fix broken wheel packages
### Fixes:
 - Some wheel packages could brake through patchelf if they already contained stripped binaries. Packages like numpy wouldn't work because of this. This is now fixed by passing `dontStrip` to the `autoPatchelf` routine.