### PR TITLE
Always quote package names

### DIFF
--- a/mach_nix/generators/overides_generator.py
+++ b/mach_nix/generators/overides_generator.py
@@ -149,7 +149,7 @@ class OverridesGenerator(ExpressionGenerator):
         )
         out = ''
         for key in sorted(other_names):
-            out += f"""    {key} = python-self.{name};\n"""
+            out += f"""    {key} = python-self."{name}";\n"""
         return out
 
     def _gen_overrides(self, pkgs: Dict[str, ResolvedPkg], overlay_keys, pkgs_names: str):


### PR DESCRIPTION
Some packages such as ["zope.interface"](https://pypi.org/project/zope.interface/) contain characters that have a special meaning in Nix if they're not quoted.