### PR TITLE
Fix ref in examples

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -33,7 +33,7 @@
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "heads/refs/2.3.0";
+    ref = "refs/tags/2.3.0";
   });
 in
 ...


### PR DESCRIPTION
I was getting the following error when copying this part from [examples.md](https://github.com/DavHau/mach-nix/blob/master/examples.md#import-mach-nix):

```sh
$ nix-shell
couldn't find remote ref heads/refs/2.3.0
error: program 'git' failed with exit code 128
```

Thought something went wrong with the project, but using the example from [README.md](https://github.com/DavHau/mach-nix#basic) works. So fix in `example.md` file too.