### PR TITLE
fix: allow for string setup/install_requires

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,11 +27,12 @@ let
   extract_requirements = python: src: name: extras:
      with pkgs.lib;
     let
+      ensureList = requires: if isString requires then [requires] else requires;
       data = extract python src ''
         Automatic requirements extraction failed for ${name}.
         Please manually specify 'requirements' '';
-      setup_requires = if hasAttr "setup_requires" data then data.setup_requires else [];
-      install_requires = if hasAttr "install_requires" data then data.install_requires else [];
+      setup_requires = if hasAttr "setup_requires" data then ensureList data.setup_requires else [];
+      install_requires = if hasAttr "install_requires" data then ensureList data.install_requires else [];
       extras_require =
         if hasAttr "extras_require" data then
           pkgs.lib.flatten (map (extra: data.extras_require."${extra}") extras)


### PR DESCRIPTION
setuptools allows for install_requires and setup_requires to be either a
string or list of strings. This commit ensures the two formats are
normalised to a list.

https://setuptools.readthedocs.io/en/latest/userguide/keywords.html#id7

For reference, I encountered this when trying to build elastalert with the following derivation:
```nix
let
  mach-nix = import (builtins.fetchGit {
    url = "https://github.com/DavHau/mach-nix/";
    ref = "refs/tags/2.4.1";
  });
in
mach-nix.buildPythonPackage {
  src = builtins.fetchGit {
    url = "https://github.com/Yelp/elastalert";
    ref = "refs/tags/0.2.4";
    rev = "7d369e41fb00127ac278a911dd8025906be46738";
  };
}

``` 