### PR TITLE
Update fixes.nix

### DIFF
--- a/mach_nix/fixes.nix
+++ b/mach_nix/fixes.nix
@@ -7,7 +7,7 @@ let
 
   # evaluate arbitrary python expression and return json parsed result
   py_eval = str: fromJSON ( readFile (
-    pkgs.runCommand "py-eval-result" { buildInputs = with pkgs; [ python python3Packages.packaging ]; } ''
+    pkgs.runCommand "py-eval-result" { buildInputs = with pkgs; [ python3 python3Packages.packaging ]; } ''
       ${pkgs.python}/bin/python -c "${str}" > $out
     ''));
 


### PR DESCRIPTION
not mixing python27 and python3x
- could be used with python defined in default.nix (args) - if python would be inherited