### PR TITLE
flake: simplify and expose overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,44 +10,12 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = nixpkgs.legacyPackages.${system};
-        mach-nix-default = import ./default.nix {inherit pkgs;};
-      in rec
-      {
-        devShell = import ./shell.nix {
-          inherit pkgs;
-        };
-        packages = flake-utils.lib.flattenTree rec {
-          inherit (mach-nix-default)
-            mach-nix
-            pythonWith
-            shellWith
-            dockerImageWith;
-          "with" = pythonWith;
-        };
-
-        defaultPackage = packages.mach-nix;
-
-        apps.mach-nix = flake-utils.lib.mkApp { drv = packages.mach-nix.mach-nix; };
-        defaultApp = { type = "app"; program = "${defaultPackage}/bin/mach-nix"; };
-
-        lib = {
-          inherit (mach-nix-default)
-            mkPython
-            mkPythonShell
-            mkDockerImage
-            mkOverlay
-            mkNixpkgs
-            mkPythonOverrides
-
-            buildPythonPackage
-            buildPythonApplication
-            fetchPypiSdist
-            fetchPypiWheel
-            ;
-        };
-      }
-  );
+    flake-utils.lib.simpleFlake {
+      inherit self nixpkgs;
+      name = "mach-nix";
+      overlay = ./overlay.nix;
+      shell = ./shell.nix;
+    } // {
+      overlay = import ./overlay.nix;
+    };
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,34 @@
+# Import this overlay in your project to add the mach-nix namespace
+final: prev:
+let
+  mach-nix-all = import ./. { pkgs = final; };
+in
+{
+  mach-nix = {
+    inherit (mach-nix-all)
+      mach-nix
+      pythonWith
+      shellWith
+      dockerImageWith
+      "with"
+      ;
+
+    defaultPackage = mach-nix-all.mach-nix;
+
+    lib = {
+      inherit (mach-nix-all)
+        mkPython
+        mkPythonShell
+        mkDockerImage
+        mkOverlay
+        mkNixpkgs
+        mkPythonOverrides
+
+        buildPythonPackage
+        buildPythonApplication
+        fetchPypiSdist
+        fetchPypiWheel
+        ;
+    };
+  };
+}


### PR DESCRIPTION
Conveniently going forth, `lib` is only exposed as overlay, since the
flake command line utility only recognizes flattened record set. As
overlay, this is no problem, though and can be accessed via
pkgs.mach-nix.lib.[...]

---

Hey Dave, this is a little convenience improvement that helps importing mach-nix into flake driven repos.

I modelled it after:
https://github.com/numtide/flake-utils/tree/master/examples


The `app` attributes are obsolete:
```nix
{
        apps.mach-nix = flake-utils.lib.mkApp { drv = packages.mach-nix.mach-nix; };
        defaultApp = { type = "app"; program = "${defaultPackage}/bin/mach-nix"; };
}
```

since the binary has the same name as the package, nix run will find it amont the `packages` output anyway.

- Note that `lib` is now exported only through an overlay (keeping the flake output schema conform).
- The overlay can be independently consumed by non-flake users (not sure how users would do that, but at least they can) while you keep control on the name-space for more concise docs.


To load the `mach-nix` namespace (as defined in `./overlay.nix`) into `pkgs` as `pkgs.mach-nix`, users would do, for example:

```nix
{
  description = "Flake utils demo";

  inputs.flake-utils.url = "github:numtide/flake-utils";
  inputs.mach-nix.url = "github:DavHau/mach-nix";

  outputs = { self, nixpkgs, flake-utils, mach-nix }:
    flake-utils.lib.simpleFlake {
      inherit self nixpkgs;
      name = "my-flake";
      preOverlays = [ mach-nix.overlay ];
    };
}
```

Todo:
- [x] test that lib is exported as desired for consumers