### PR TITLE
Fix outdated error message that is presented when pypy-deps-db is outdated

### DIFF
--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -184,9 +184,10 @@ class CombinedDependencyProvider(DependencyProviderBase):
                               f"Consider adding them via 'providers='"
         else:
             error_text += \
-                f"\nIf the package's initial release date predates the release date of mach-nix, " \
-                f"either upgrade mach-nix itself or manually specify 'pypi_deps_db_commit' and\n" \
-                f"'pypi_deps_db_sha256 for a newer commit of https://github.com/DavHau/pypi-deps-db/commits/master\n" \
+                f"\nIf the package's initial release date predates the release date of mach-nix,\n" \
+                f"either upgrade mach-nix itself or set 'pypiDataRev' and 'pypiDataSha256'\n" \
+                f"to a more recent commit of https://github.com/DavHau/pypi-deps-db/commits/master\n" \
+                f"when importing mach-nix.\n" \
                 f"If it still doesn't work, there was probably a problem while crawling pypi.\n" \
                 f"Please open an issue at: https://github.com/DavHau/mach-nix/issues/new\n"
         print(error_text, file=sys.stderr)

--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -175,13 +175,14 @@ class CombinedDependencyProvider(DependencyProviderBase):
 
     def print_error_no_versions_available(self, pkg_name):
         provider_names = set(self.allowed_providers_for_pkg(pkg_name).keys())
-        error_text = f"\nThe Package '{pkg_name}' is not available from any of the " \
-                     f"selected providers {provider_names}\n for the selected python version"
+        error_text = \
+            f"\nThe Package '{pkg_name}' is not available from any of the selected providers\n" \
+            f"{provider_names} for the selected python version."
         if provider_names != set(self._all_providers.keys()):
             alternative_providers = self.list_all_providers_for_pkg(pkg_name)
             if alternative_providers:
-                error_text += f'... but the package is is available from providers {alternative_providers}\n' \
-                              f"Consider adding them via 'providers='"
+                error_text += f'\nThe package is is available from providers {alternative_providers}\n' \
+                              f"Consider adding them via 'providers='."
         else:
             error_text += \
                 f"\nIf the package's initial release date predates the release date of mach-nix,\n" \


### PR DESCRIPTION
The original error message still references the deprecated way of setting the version of `pypi-deps-db`.

This PR fixes that and makes some improvements in the error message text/formatting.