### PR TITLE
README: refs/heads/{version} -> refs/tags/

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,7 +102,7 @@ You can call mach-nix directly from a nix expression
 let
   mach-nix = import (builtins.fetchGit {
     url = "https://github.com/DavHau/mach-nix/";
-    ref = "refs/heads/3.3.0";
+    ref = "refs/tags/3.3.0";
   }) {};
 in
 mach-nix.mkPython {


### PR DESCRIPTION
The README example didn't work, due to an incorrect git ref.
It now works with this commit.