### PR TITLE
Add support for manylinux_${GLIBCMAJOR}_${GLIBCMINOR} wheels

### DIFF
--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -300,6 +300,9 @@ class WheelDependencyProvider(DependencyProviderBase):
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux2014_{self.platform}"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux2010_{self.platform}"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux1_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux_2_5_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux_2_12_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux_2_17_{self.platform}"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-linux_{self.platform}"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-any"),
             )

--- a/mach_nix/tests/test_providers.py
+++ b/mach_nix/tests/test_providers.py
@@ -13,6 +13,10 @@ from mach_nix.versions import PyVer
     (True, '3.6.0', 'PyQt5-5.15.1-5.15.1-cp35.cp36.cp37-abi3-manylinux2014_x86_64.whl', "linux", "x86_64"),
     (True, '3.7.0', 'PyQt5-5.15.1-5.15.1-cp35.cp36.cp37-abi3-manylinux2014_x86_64.whl', "linux", "x86_64"),
     (False, '3.8.0', 'PyQt5-5.15.1-5.15.1-cp35.cp36.cp37-abi3-manylinux2014_x86_64.whl', "linux", "x86_64"),
+    # manylinux_${GLIBCMAJOR}_${GLIBCMINOR}
+    (True, '3.9.0', 'pymaid-1.0.0a1-cp39-cp39-manylinux_2_5_x86_64.whl', "linux", "x86_64"),
+    # combination of manylinux GLIBC* and YEAR formats
+    (True, '3.6.0', 'tokenizers-0.10.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl', "linux", "x86_64"),
     # none-any wheels for py2 + py3
     (True, '2.7.0', 'requests-2.24.0-py2.py3-none-any.whl', "linux", "x86_64"),
     (True, '3.8.0', 'requests-2.24.0-py2.py3-none-any.whl', "linux", "x86_64"),


### PR DESCRIPTION
https://www.python.org/dev/peps/pep-0600/

This fixes e.g. using the latest tokenizers package (0.10.3) with
mach-nix.

TODO: Update WheelDependencyProvider to process all filename tags
individually instead of matching them all with a single regexp. If it
had done that already, this change would have been somewhat unneeded, as
all wheel files seem to be doubly tagged (at least for now):

* manylinux_2_5 is also tagged manylinux1
* manylinux_2_12 is also tagged manylinux2010
* manylinux_2_17 is also tagged manylinux2014

(But since the new format is first in the filename, the old regexps
don't match.)

Fixes https://github.com/DavHau/mach-nix/issues/300.

--

@DavHau: I grepped the repo for `manylinux`, found some tests, added two test cases for the new format and hacked the source until the tests passed. Then I wrote a small `mach-nix.mkPython` using a `tokenizers==0.10.3` (which failed before) and saw it pass.