### PR TITLE
Remove trailing slash in mach-nix git url

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -101,7 +101,7 @@ You can call mach-nix directly from a nix expression
 ```nix
 let
   mach-nix = import (builtins.fetchGit {
-    url = "https://github.com/DavHau/mach-nix/";
+    url = "https://github.com/DavHau/mach-nix";
     ref = "refs/tags/3.3.0";
   }) {};
 in

--- a/examples.md
+++ b/examples.md
@@ -44,7 +44,7 @@ every mach-nix expression should begin like this:
 ```nix
 let
   mach-nix = import (builtins.fetchGit {
-    url = "https://github.com/DavHau/mach-nix/";
+    url = "https://github.com/DavHau/mach-nix";
     ref = "refs/tags/3.3.0";
   }) {
     # optionally bring your own nixpkgs
@@ -280,7 +280,7 @@ In this example, mach-nix is used to resolve our python dependencies and provide
 ```nix
 let
   mach-nix = import (builtins.fetchGit {
-    url = "https://github.com/DavHau/mach-nix/";
+    url = "https://github.com/DavHau/mach-nix";
     ref = "refs/heads/3.3.0";  # update this version
   }) {
     python = "python37";
@@ -402,7 +402,7 @@ For the SD-image, create a configuration.nix file which adds the mach-nix tool a
 
 let
   machNix = import (builtins.fetchGit {
-    url = "https://github.com/DavHau/mach-nix/";
+    url = "https://github.com/DavHau/mach-nix";
     ref = "refs/tags/put_version_here";
   }) { inherit pkgs; };
 

--- a/pypi-crawlers/nix/python.nix
+++ b/pypi-crawlers/nix/python.nix
@@ -1,6 +1,6 @@
 let
   mach-nix = import (builtins.fetchGit {
-    url = "https://github.com/DavHau/mach-nix/";
+    url = "https://github.com/DavHau/mach-nix";
     ref = "refs/tags/3.2.0";
   }) {};
 in


### PR DESCRIPTION
The patch is silly, but I hope the argumentation makes some sense.

I've been struggling a while to find out what was going on as even the most basic example like
```
let
  mach-nix = import (builtins.fetchGit {
    url = "https://github.com/DavHau/mach-nix/";
    ref = "refs/tags/3.3.0";
  }) {};
in
mach-nix.mkPython {
  requirements = ''
    pillow
    numpy
    requests
  '';
}
``` 
wasn't working for me and I got a weird git error.

In my .gitconfig I had:
```
[url "git@github.com:"]
       insteadOf = https://github.com/
```

I did some checks and:

`git clone git@github.com:DavHau/mach-nix` ✅ 
`git clone git@github.com:DavHau/mach-nix.git` ✅ 
`git clone git@github.com:DavHau/mach-nix/`  🔴  

`git clone https://github.com/DavHau/mach-nix` ✅ 
`git clone https://github.com/DavHau/mach-nix.git` ✅ 
`git clone https://github.com/DavHau/mach-nix/` ✅ 
`git clone https://github.com/DavHau/mach-nix//` ✅ 

so you see when `https://github.com/DavHau/mach-nix/` gets changed to `git@github.com:DavHau/mach-nix/` you get an error, therefore no trailing slash or .git at the end of url is "safer" in order to avoid headache if somebody else has similar settings.