### PR TITLE
Handle more case of nixpkgs version matching.

### DIFF
--- a/mach_nix/data/nixpkgs.py
+++ b/mach_nix/data/nixpkgs.py
@@ -73,7 +73,7 @@ class NixpkgsIndex(UserDict):
             return pkgs[0].nix_key
         # try to find nixpkgs candidate with closest version
         remaining_pkgs = pkgs
-        for i in range(7):  # usually there are not more than 4 parts in a version
+        for i in range(len(ver.version)):
             same_ver = list(filter(lambda p: self.is_same_ver(ver, p.ver, i), remaining_pkgs))
             if len(same_ver) == 1:
                 return same_ver[0].nix_key


### PR DESCRIPTION
While working on a fix for #232, I discovered a case where the loop in `NixpkgsIndex.find_best_nixpkgs_candidate` could fall off the end. With the current code, this will only happen if there are two nixpkgs that match the desired version to 6 places[1], so is unlikely to happen in practice. But, it seems reasonable to handle that case the same as if we had multiple packages that have the same length of matching prefix, rather than erroring.

[1] The conda version model includes an epoch as the first element of `.version`, which can't occur in nixpkgs versions.