### PR TITLE
Track raw provider version, rather than rebuilding.

### DIFF
--- a/mach_nix/deptree.py
+++ b/mach_nix/deptree.py
@@ -28,7 +28,7 @@ def mark_removed_circular_dep(pkgs: Dict[str, ResolvedPkg], G: DiGraph, node, re
 
 
 def remove_dependecy(pkgs: Dict[str, ResolvedPkg], G: DiGraph, node_from, node_to):
-    if node_to in pkgs[node_from].build_inputs:
+    if pkgs[node_from].build_inputs is not None and node_to in pkgs[node_from].build_inputs:
         raise Exception(
             f"Fata error: cycle detected in setup requirements\n"
             f"Cannot fix automatically.\n{[node_from, node_to]}")
@@ -75,7 +75,7 @@ def remove_circles_and_print(pkgs: Iterable[ResolvedPkg], nixpkgs: NixpkgsIndex)
 
         def name(self, node_name):
             if node_name in self.visited:
-                if indexed_pkgs[node_name].build_inputs + indexed_pkgs[node_name].prop_build_inputs == []:
+                if indexed_pkgs[node_name].build_inputs or indexed_pkgs[node_name].prop_build_inputs:
                     return make_name(indexed_pkgs[node_name], nixpkgs)
                 return f"{make_name(indexed_pkgs[node_name], nixpkgs)} -> ..."
             return make_name(indexed_pkgs[node_name], nixpkgs)

--- a/mach_nix/generators/overides_generator.py
+++ b/mach_nix/generators/overides_generator.py
@@ -1,5 +1,5 @@
 import json
-from typing import Dict, List
+from typing import Dict
 
 from mach_nix.data.providers import WheelDependencyProvider, SdistDependencyProvider, NixpkgsDependencyProvider, \
     CondaDependencyProvider
@@ -348,7 +348,7 @@ class OverridesGenerator(ExpressionGenerator):
                 if self.nixpkgs.exists(pkg.name):
                     out += self._gen_overrideAttrs(
                         pkg.name,
-                        pkg.provider_info.provider.deviated_version(pkg.name, pkg.ver, pkg.build),
+                        pkg.raw_version,
                         pkg.removed_circular_deps,
                         nix_name,
                         'sdist',
@@ -357,7 +357,7 @@ class OverridesGenerator(ExpressionGenerator):
                 else:
                     out += self._gen_buildPythonPackage(
                         pkg.name,
-                        pkg.provider_info.provider.deviated_version(pkg.name, pkg.ver, pkg.build),
+                        pkg.raw_version,
                         pkg.removed_circular_deps,
                         nix_name,
                         build_inputs_str,
@@ -366,7 +366,7 @@ class OverridesGenerator(ExpressionGenerator):
             elif isinstance(pkg.provider_info.provider, WheelDependencyProvider):
                 out += self._gen_wheel_buildPythonPackage(
                     pkg.name,
-                    pkg.provider_info.provider.deviated_version(pkg.name, pkg.ver, pkg.build),
+                    pkg.raw_version,
                     pkg.removed_circular_deps,
                     self._get_ref_name(pkg.name, pkg.ver),
                     prop_build_inputs_str,
@@ -375,7 +375,7 @@ class OverridesGenerator(ExpressionGenerator):
             elif isinstance(pkg.provider_info.provider, CondaDependencyProvider):
                 out += self._gen_conda_buildPythonPackage(
                     pkg.name,
-                    pkg.provider_info.provider.deviated_version(pkg.name, pkg.ver, pkg.build),
+                    pkg.raw_version,
                     pkg.removed_circular_deps,
                     self._get_ref_name(pkg.name, pkg.ver),
                     prop_build_inputs_str,

--- a/mach_nix/resolver/__init__.py
+++ b/mach_nix/resolver/__init__.py
@@ -13,6 +13,7 @@ from json import JSONEncoder
 class ResolvedPkg(JSONEncoder):
     name: str
     ver: Version
+    raw_version: str
     build_inputs: Optional[List[str]]
     prop_build_inputs: Optional[List[str]]
     is_root: bool

--- a/mach_nix/resolver/resolvelib_resolver.py
+++ b/mach_nix/resolver/resolvelib_resolver.py
@@ -73,6 +73,7 @@ class ResolvelibResolver(Resolver):
             nix_py_pkgs.append(ResolvedPkg(
                 name=name,
                 ver=ver,
+                raw_version=candidate.raw_version,
                 build_inputs=build_inputs,
                 prop_build_inputs=prop_build_inputs,
                 is_root=is_root,


### PR DESCRIPTION
While working on #334, I discovered that provider logic was doing a bunch of duplicate work because it wasn't preserving data it already had. This preserves the provider-known version (which is what `deviated_version` was calculating), as well as the raw package data from the provider, which is used for calculating requirements, without having to re-find the package.

I *think* this changes what conda build gets picked, it should now always pick the highest matching build number. I think previously it was random, if there were no build restrictions, and the *lowest* if there were restrictions.
