### PR TITLE
correctly parse requirements that end in a stray comma

### DIFF
--- a/mach_nix/requirements.py
+++ b/mach_nix/requirements.py
@@ -130,6 +130,9 @@ def parse_reqs_line(line):
         line = init + ';' + marker
     else:
         line = line.replace("'", "").replace('"', '')
+    
+    if line.endswith(','):
+        line = line[:-1]
 
     match = re.fullmatch(re_reqs, line)
     if not match:


### PR DESCRIPTION
Somewhere in my requirements there lurks openyxl which failed 
to install because of a stray comma at the end of python_requires.

This eats those commas.