### PR TITLE
Match macosx_11_0_arm64.wheel

### DIFF
--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -310,6 +310,7 @@ class WheelDependencyProvider(DependencyProviderBase):
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-any"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_universal"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_x86_64"),
+                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_arm64"),
             )
         else:
             raise Exception(f"Unsupported Platform {platform.system()}")


### PR DESCRIPTION
e.g. `numpy-1.21.4-cp310-cp310-macosx_11_0_arm64.whl`  https://pypi.org/project/numpy/#files