### PR TITLE
Ignore direct references in requirements

### DIFF
--- a/mach_nix/requirements.py
+++ b/mach_nix/requirements.py
@@ -122,6 +122,10 @@ def parse_reqs_line(line):
     if line.endswith("==*"):
         line = line[:-3]
 
+    # Throw away direct references.
+    if "@" in line:
+        line = line.split("@")[0]
+
     # remove ' symbols
     split = line.split(';')
     if len(split) > 1:


### PR DESCRIPTION
Here's a straw-man.  It makes builds with requirements with direct references "work" (by just ignoring the direct reference completely).

Relates to #352 