### PR TITLE
Remove the dependency on python pkgconfig package in the dependency extractor.

### DIFF
--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -82,7 +82,6 @@ let
       python_env = python.withPackages (ps: with ps; [
         # base requirements
         setuptools
-        pkgconfig
       ]);
     in
       patchDistutils python_env;


### PR DESCRIPTION
This causes dependency extraction to fail on python2, with nixos-21.11.