### PR TITLE
Add an example using a Flake

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -3,6 +3,7 @@ This page contains basic and advanced examples for using mach-nix inside a nix e
 
 <!--ts-->
   * [Import mach-nix](#import-mach-nix)
+  * [Use mach-nix from a Flake](#use-mach-nix-from-a-flake)
   * [mkPython / mkPythonShell](#mkpython--mkpythonshell)
     * [From a list of requirements](#from-a-list-of-requirements)
     * [Include extra packages.](#include-extra-packages)
@@ -59,6 +60,37 @@ let
   };
 in
 ...
+```
+
+### Use mach-nix from a Flake
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+    mach-nix = {
+      url = "github:DavHau/mach-nix?ref=3.3.0";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+        flake-utils.follows = "flake-utils";
+      };
+    };
+  };
+  outputs = { self, nixpkgs, flake-utils, mach-nix, ...}@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages."${system}";
+        mach-nix = mach-nix.lib."${system}";
+      in {
+        devShell = mach-nix.mkPythonShell {
+          requirements = ''
+            pillow
+            numpy
+            requests
+          '';
+        };
+    });
+}
 ```
 
 ### mkPython / mkPythonShell


### PR DESCRIPTION
It seems there is no documentation on how to use mach-nix with Flakes. Looking a bit around the issues and `flake.nix`, I think this is the right way. If one wants to override pypi deps, I am a bit unsure what the right solution is. I don't know if it's worth putting it in the documentation. If yes, I suppose this is:

```nix
inputs = {
    nixpkgs.url = "github:nixos/nixpkgs";
    flake-utils.url = "github:numtide/flake-utils";
    pypi-deps-db = {
      url = github:DavHau/pypi-deps-db/99799f6300b2dc4a4063dc3da032f5f169709567;
      flake = false;
    };
    mach-nix = {
      url = "github:DavHau/mach-nix?ref=3.3.0";
      inputs = {
        nixpkgs.follows = "nixpkgs";
        flake-utils.follows = "flake-utils";
        pypi-deps-db.follows = "pypi-deps-db";
      };
    };
}
```

From my understanding, the default values already contain reference to inputs.