### PR TITLE
allow conda hash to be an md5 sum

### DIFF
--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -600,10 +600,10 @@ class CondaDependencyProvider(DependencyProviderBase):
         candidates = []
         for ver in self.pkgs[pkg_name].keys():
             for p in self.compatible_builds(pkg_name, parse_ver(ver), build):
-                if 'sha256' not in p:
+                if 'sha256' not in p and 'md5' not in p:
                     print(
                         f"Ignoring conda package {p['name']}:{p['version']} from provider {self.channel} \n"
-                        "since it doesn't provide a sha256 sum.\n")
+                        "since it doesn't provide a sha256 or md5 sum.\n")
                 else:
                     if self.channel in ('free', 'intel', 'main', 'r'):
                         url = f"https://repo.anaconda.com/pkgs/{self.channel}/{p['subdir']}/{p['fname']}"
@@ -618,7 +618,7 @@ class CondaDependencyProvider(DependencyProviderBase):
                         provider_info=ProviderInfo(
                             self,
                             url=url,
-                            hash=p['sha256']
+                            hash=p.get('sha256', p["md5"])
                         )
                     ))
                     if 'collisions' in p:


### PR DESCRIPTION
Not sure whether this is the right thing to do but it does allow resolving the [`cadquery`](https://anaconda.org/CadQuery/cadquery) package from conda.

Without this change, the following `shell.nix` file

```nix
let mach-nix = import (builtins.fetchGit {
  url = "https://github.com/DavHau/mach-nix";  
    }) {
      condaChannelsExtra.cadquery = [
        (builtins.fetchurl "https://conda.anaconda.org/cadquery/linux-64/repodata.json")
      ];
    }; in
mach-nix.mkPython {
  requirements = ''
    cadquery   
  '';                           
  providers = {                  
    cadquery = "conda/cadquery";
  };
}
```

throws this error:

```
❯ nix-shell
trace: using conda channels: cadquery
building '/nix/store/nmwszcmgfckid8gbyygwyy6xyagc3hrr-mach_nix_file.drv'...
Ignoring conda package cadquery:master from provider cadquery 
since it doesn't provide a sha256 sum.

Ignoring conda package cadquery:2.1RC1 from provider cadquery 
since it doesn't provide a sha256 sum.

Ignoring conda package cadquery:merge from provider cadquery 
since it doesn't provide a sha256 sum.

Ignoring conda package cadquery:2.1 from provider cadquery 
since it doesn't provide a sha256 sum.


The Package 'cadquery' (build: None) is not available from any of the selected providers ['conda/cadquery']
 for the selected python version
The package is is available from providers ['wheel', 'sdist']
Consider adding them via 'providers='.
error: builder for '/nix/store/nmwszcmgfckid8gbyygwyy6xyagc3hrr-mach_nix_file.drv' failed with exit code 1;
       last 10 log lines:
       > since it doesn't provide a sha256 sum.
       >
       > Ignoring conda package cadquery:2.1 from provider cadquery
       > since it doesn't provide a sha256 sum.
       >
       >
       > The Package 'cadquery' (build: None) is not available from any of the selected providers ['conda/cadquery']
       >  for the selected python version
       > The package is is available from providers ['wheel', 'sdist']
       > Consider adding them via 'providers='.
       For full logs, run 'nix log /nix/store/nmwszcmgfckid8gbyygwyy6xyagc3hrr-mach_nix_file.drv'.
(use '--show-trace' to show detailed location information)
```

Adding the change in this PR allows `mach-nix` to resolve that package but it then throws a new error.

```
The Package 'python-abi' (build: *_cp38) is not available from any of the selected providers ['conda/cadquery', 'nixpkgs', 'sdist', 'wheel']
 for the selected python version
```

So I added `providers._default = "cadquery,conda-forge,wheel,sdist,nixpkgs";` and the next dependency that cannot be resolved is `pypy`.

```
The Package 'pypy' (build: None) is not available from any of the selected providers ['conda/cadquery', 'conda/conda-forge', 'nixpkgs', 'sdist', 'wheel']
 for the selected python version
```

Which I believe is #199. So I haven't been able to test whether using the md5 for a package hash results in a working install but wanted to open this PR anyway in case someone else knows a fix and/or whether this change is valid.