### PR TITLE
Update dependencies of python packages specified in packagesExtra in mkPython.

### DIFF
--- a/mach_nix/data/nixpkgs.py
+++ b/mach_nix/data/nixpkgs.py
@@ -24,11 +24,12 @@ class NixpkgsIndex(UserDict):
         with open(nixpkgs_json_file) as f:
             data = json.load(f)
         self.data = {}
-        for nix_key, s in data.items():
-            if '@' not in s:
+        for nix_key, nix_data in data.items():
+            if nix_data is None:
                 continue
-            pname, version = s.split('@')
-            pname_key = pname.replace('_', '-').lower()
+            pname = nix_data["pname"]
+            version = parse_ver(nix_data["version"])
+            pname_key = pname.replace("_", "-").lower()
             if pname_key not in self.data:
                 self.data[pname_key] = {}
             if version not in self.data[pname_key]:
@@ -47,7 +48,7 @@ class NixpkgsIndex(UserDict):
     def get_all_candidates(self, name) -> List[NixpkgsPyPkg]:
         result = []
         for ver, nix_keys in self.data[name].items():
-            result += [NixpkgsPyPkg(name, nix_key, parse_ver(ver)) for nix_key in nix_keys]
+            result += [NixpkgsPyPkg(name, nix_key, ver) for nix_key in nix_keys]
         return result
 
     def get_highest_ver(self, pkgs: List[NixpkgsPyPkg]):

--- a/mach_nix/data/nixpkgs.py
+++ b/mach_nix/data/nixpkgs.py
@@ -24,6 +24,7 @@ class NixpkgsIndex(UserDict):
         with open(nixpkgs_json_file) as f:
             data = json.load(f)
         self.data = {}
+        self.requirements = {}
         for nix_key, nix_data in data.items():
             if nix_data is None:
                 continue
@@ -35,6 +36,8 @@ class NixpkgsIndex(UserDict):
             if version not in self.data[pname_key]:
                 self.data[pname_key][version] = []
             self.data[pname_key][version].append(nix_key)
+            if nix_data["requirements"] is not None:
+                self.requirements[nix_key] = nix_data["requirements"]
         super(NixpkgsIndex, self).__init__(self.data, **kwargs)
 
     def has_multiple_candidates(self, name):
@@ -107,3 +110,7 @@ class NixpkgsIndex(UserDict):
         if ver:
             return any(ver == c.ver for c in candidates)
         return True
+
+    def get_requirements(self, name, ver):
+        nix_key = self.find_best_nixpkgs_candidate(name, ver)
+        return self.requirements.get(nix_key)

--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -246,6 +246,9 @@ class NixpkgsDependencyProvider(DependencyProviderBase):
     def get_pkg_reqs(self, c: Candidate) -> Tuple[List[Requirement], List[Requirement]]:
         if not self.nixpkgs.exists(c.name, c.ver):
             raise Exception(f"Cannot find {c.name}:{c.ver} in nixpkgs")
+        requirements = self.nixpkgs.get_requirements(c.name, c.ver)
+        if requirements is not None:
+            return list(parse_reqs(requirements)), []
         install_reqs, setup_reqs = [], []
         for provider in (self.sdist_provider, self.wheel_provider):
             try:

--- a/mach_nix/nix/nixpkgs-json.nix
+++ b/mach_nix/nix/nixpkgs-json.nix
@@ -18,6 +18,8 @@ let
   };
 
   py = python.override { packageOverrides = mergeOverrides ( overrides ++ [ pnamePassthruOverride ] ); };
+
+  l = import ./lib.nix { inherit (pkgs) lib; inherit pkgs; };
 in
 
 with pkgs;
@@ -28,9 +30,10 @@ let
     let
       p = python.pkgs."${attrname}";
       pname = get_pname p;
+      requirements = p.requirements or null;
       res = if pname != "" && p ? version then
         {
-          inherit pname;
+          inherit pname requirements;
           version = (toString p.version);
         }
       else

--- a/mach_nix/nix/nixpkgs-json.nix
+++ b/mach_nix/nix/nixpkgs-json.nix
@@ -26,14 +26,17 @@ with builtins;
 let
   pname_and_version = python: attrname:
     let
-      pname = get_pname python.pkgs."${attrname}";
-      res = tryEval (
-        if pname != "" && hasAttrByPath ["${attrname}" "version"] python.pkgs
-        then pname + "@" + (toString python.pkgs."${attrname}".version)
-        else "N/A"
-      );
+      p = python.pkgs."${attrname}";
+      pname = get_pname p;
+      res = if pname != "" && p ? version then
+        {
+          inherit pname;
+          version = (toString p.version);
+        }
+      else
+        null;
     in
-      {"${attrname}" = (toString res.value);};
+      { "${attrname}" = res; };
 
   get_pname = pkg:
     let


### PR DESCRIPTION
Otherwise, it is likely that there will be collisions building the python environment,
as the dependencies of packages in packagesExtra won't match with the dependencies
calculated by mach-nix.

As a side-effect, this also causes the dependencies of mach-nix built packages included
by the `nixpkgs` provider to be included in dependency resolution.