### PR TITLE
use pkgs.python3 instead of pkgs.python(2)

### DIFF
--- a/mach_nix/fixes.nix
+++ b/mach_nix/fixes.nix
@@ -8,7 +8,7 @@ let
   # evaluate arbitrary python expression and return json parsed result
   py_eval = str: fromJSON ( readFile (
     pkgs.runCommand "py-eval-result" { buildInputs = with pkgs; [ python3 python3Packages.packaging ]; } ''
-      ${pkgs.python}/bin/python -c "${str}" > $out
+      ${pkgs.python3}/bin/python -c "${str}" > $out
     ''));
 
   # compare two python versions


### PR DESCRIPTION
fixes an error that has recently emerged for me:
```
error: builder for '/nix/store/slbbyvcpivzj9inwi0mq1vkaa6qypc77-py-eval-result.drv' failed with exit code 1;
       last 6 log lines:
       > Traceback (most recent call last):
       >   File "<string>", line 2, in <module>
       >   File "/nix/store/k07820lv55ziin5v4v9h91rah86qh7qq-python3.9-packaging-21.3/lib/python3.9/site-packages/packaging/version.py", line 42
       >     def parse(version: str) -> Union["LegacyVersion", "Version"]:
       >                      ^
       > SyntaxError: invalid syntax
       For full logs, run 'nix log /nix/store/slbbyvcpivzj9inwi0mq1vkaa6qypc77-py-eval-result.drv'.
```