### PR TITLE
Fix unwanted dependency removal; update nixpkgs + deps-db

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   description = "Create highly reproducible python environments";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.pypi-deps-db = {
     url = "github:DavHau/pypi-deps-db";
     flake = false;

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
-echo -n "$(git branch --show-current)" > ./mach_nix/VERSION
-git add ./mach_nix/VERSION
+currBranch="$(git branch --show-current)"
+if [ $currBranch == "master" ]; then
+  echo -n "$currBranch" > ./mach_nix/VERSION
+  git add ./mach_nix/VERSION
+fi

--- a/mach_nix/VERSION
+++ b/mach_nix/VERSION
@@ -1,1 +1,1 @@
-master
+macos-arm64

--- a/mach_nix/VERSION
+++ b/mach_nix/VERSION
@@ -1,1 +1,1 @@
-macos-arm64
+master

--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -309,10 +309,11 @@ class WheelDependencyProvider(DependencyProviderBase):
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-any"),
             )
         elif self.system == "darwin":
+            platform = "arm64" if self.platform == "aarch64" else self.platform
             self.preferred_wheels = (
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-any"),
                 re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_universal"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_{platform}"),
             )
         else:
             raise Exception(f"Unsupported Platform {platform.system()}")

--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -266,7 +266,7 @@ class NixpkgsDependencyProvider(DependencyProviderBase):
             return self.sdist_provider.get_pkg_reqs(c)
         except PackageNotFound:
             try:
-                # wheel provider onyl knows install deps
+                # wheel provider only knows install deps
                 return self.wheel_provider.get_pkg_reqs(c)[0], None
             except:
                 return None, None

--- a/mach_nix/deptree.py
+++ b/mach_nix/deptree.py
@@ -47,7 +47,12 @@ def remove_circles_and_print(pkgs: Iterable[ResolvedPkg], nixpkgs: NixpkgsIndex)
 
     edges = set()
     for p in pkgs:
-        for child in p.build_inputs + p.prop_build_inputs:
+        build_inputs, prop_build_inputs = [], []
+        if p.build_inputs is not None:
+            build_inputs = p.build_inputs
+        if p.prop_build_inputs is not None:
+            prop_build_inputs = p.prop_build_inputs
+        for child in build_inputs + prop_build_inputs:
             edges.add((p.name, child))
     G = nx.DiGraph(sorted(list(edges)))
 
@@ -79,7 +84,13 @@ def remove_circles_and_print(pkgs: Iterable[ResolvedPkg], nixpkgs: NixpkgsIndex)
             if node_name in self.visited:
                 return []
             self.visited.add(node_name)
-            return list(set(indexed_pkgs[node_name].build_inputs + indexed_pkgs[node_name].prop_build_inputs))
+            p = indexed_pkgs[node_name]
+            build_inputs, prop_build_inputs = [], []
+            if p.build_inputs is not None:
+                build_inputs = p.build_inputs
+            if p.prop_build_inputs is not None:
+                prop_build_inputs = p.prop_build_inputs
+            return list(set(build_inputs + prop_build_inputs))
 
     for root in roots:
         limiter = Limiter()

--- a/mach_nix/flake.lock
+++ b/mach_nix/flake.lock
@@ -17,27 +17,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643247693,
-        "narHash": "sha256-rmShxIuNjYBz4l83J0J++sug+MURUY1koPCzX4F8hfo=",
+        "lastModified": 1643805626,
+        "narHash": "sha256-AXLDVMG+UaAGsGSpOtQHPIKB+IZ0KSd9WS77aanGzgc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c4b9f1a2fd761e2d384ef86cff0d208ca27fdca",
+        "rev": "554d2d8aa25b6e583575459c297ec23750adb6cb",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.11",
+        "ref": "nixos-unstable",
         "type": "indirect"
       }
     },
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1643315438,
-        "narHash": "sha256-yIWwRq/ckGwsFA/tojhJl5bBZdPREotRLfUS4n+x7v0=",
+        "lastModified": 1643877077,
+        "narHash": "sha256-jv8pIvRFTP919GybOxXE5TfOkrjTbdo9QiCO1TD3ZaY=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "f251b0ec37b796d7ac4125251d65724427870ef0",
+        "rev": "da53397f0b782b0b18deb72ef8e0fb5aa7c98aa3",
         "type": "github"
       },
       "original": {

--- a/mach_nix/nix/CONDA_CHANNELS.json
+++ b/mach_nix/nix/CONDA_CHANNELS.json
@@ -1,8 +1,12 @@
 {
   "url": "https://github.com/davhau/conda-channels",
-  "rev": "21371cb199615f3e3ff468fe8c756e30fe74ce45",
-  "date": "2020-11-20T14:00:42+00:00",
-  "sha256": "",
+  "rev": "da2ce5d116065f00e1fdfd144dbafbb8ae727bd3",
+  "date": "2022-02-03T06:37:09+00:00",
+  "path": "/nix/store/f22n3yv11dhxd1hrclf6v4045dcja4vb-conda-channels",
+  "sha256": "12yivv4a3xkml4m8qyb79aw6sfg6igarknvxggjy1r2snc57krvs",
+  "fetchLFS": false,
   "fetchSubmodules": false,
-  "indexSha256": "0grj7v376cwszqcb53dmbgbj53wmi5pzvxrcifmxmmh6r845bid7"
+  "deepClone": false,
+  "leaveDotGit": false,
+  "indexSha256": "5cc83b205f3358fc0ba7c96cc36a29e568a0a01df23b78337a134194e358d1c0"
 }

--- a/mach_nix/nix/compileOverrides.nix
+++ b/mach_nix/nix/compileOverrides.nix
@@ -41,8 +41,8 @@ let
   nixpkgs_json = import ./nixpkgs-json.nix {
     inherit overrides pkgs python;
   };
-  builder_python = pkgs.pkgsBuildHost.python38.withPackages(ps:
-    (pkgs.lib.attrValues (import ./python-deps.nix {python = pkgs.python38; fetchurl = pkgs.fetchurl; }))
+  builder_python = pkgs.pkgsBuildHost.python39.withPackages(ps:
+    (pkgs.lib.attrValues (import ./python-deps.nix {python = pkgs.python39; fetchurl = pkgs.fetchurl; }))
   );
 
   src = ./../../.;

--- a/mach_nix/nix/lib.nix
+++ b/mach_nix/nix/lib.nix
@@ -202,7 +202,7 @@ rec {
           src = src;
         }}/python.json";
     in
-      if pathExists file_path then fromJSON (readFile file_path) else throw fail_msg;
+      if pathExists file_path then fromJSON (builtins.unsafeDiscardStringContext (readFile file_path)) else throw fail_msg;
 
   extract_requirements = python: src: name: extras:
     let

--- a/mach_nix/nix/python.nix
+++ b/mach_nix/nix/python.nix
@@ -6,7 +6,7 @@
 }:
 let
   lib = pkgs.lib;
-  python = pkgs.python38;
+  python = pkgs.python39;
   pythonDeps = (lib.attrValues (import ./python-deps.nix { inherit python; fetchurl = pkgs.fetchurl; }));
   pythonDepsDev = with python.pkgs; [
     pytest_6

--- a/mach_nix/nix/update-deps.sh
+++ b/mach_nix/nix/update-deps.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
 set -e
-nix-shell -p nix-prefetch-git --run  "nix-prefetch-git --url https://github.com/davhau/pypi-deps-db --rev refs/heads/master  --no-deepClone" | python -m json.tool - PYPI_DEPS_DB.json
-nix-shell -p nix-prefetch-git --run  "nix-prefetch-git --url https://github.com/nixos/nixpkgs --rev refs/heads/nixpkgs-unstable  --no-deepClone" | python -m json.tool - NIXPKGS.json
 nix-shell -p nix-prefetch-git --run  "nix-prefetch-git --url https://github.com/davhau/conda-channels --rev refs/heads/master  --no-deepClone" | python -m json.tool - CONDA_CHANNELS.json
 jq --arg hash $(curl -L https://raw.githubusercontent.com/DavHau/conda-channels/master/sha256.json | sha256sum | awk '{ print $1 }') '. + {indexSha256: $hash}' CONDA_CHANNELS.json > C.json && mv C.json CONDA_CHANNELS.json

--- a/mach_nix/resolver/__init__.py
+++ b/mach_nix/resolver/__init__.py
@@ -1,24 +1,39 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Iterable, Set
+from typing import List, Optional, Iterable, Set
 
 from mach_nix.data.providers import ProviderInfo
 from mach_nix.requirements import Requirement
 from mach_nix.versions import Version
 
+from json import JSONEncoder
+
 
 @dataclass
-class ResolvedPkg:
+class ResolvedPkg(JSONEncoder):
     name: str
     ver: Version
-    build_inputs: List[str]
-    prop_build_inputs: List[str]
+    build_inputs: Optional[List[str]]
+    prop_build_inputs: Optional[List[str]]
     is_root: bool
     provider_info: ProviderInfo
     extras_selected: List[str]
     # contains direct or indirect children wich have been diconnected due to circular deps
     removed_circular_deps: Set[str] = field(default_factory=set)
     build: str = None
+
+    def toDict(self):
+        return dict(
+            name=self.name,
+            ver=str(self.ver),
+            build_inputs=self.build_inputs,
+            prop_build_inputs=self.prop_build_inputs,
+            is_root=self.is_root,
+            provider_info=self.provider_info.toDict(),
+            extras_selected=self.extras_selected,
+            removed_circular_deps=list(self.removed_circular_deps),
+            build=self.build,
+        )
 
 
 class Resolver(ABC):

--- a/mach_nix/resolver/resolvelib_resolver.py
+++ b/mach_nix/resolver/resolvelib_resolver.py
@@ -37,6 +37,10 @@ class Provider(resolvelib.providers.AbstractProvider):
 
     def get_dependencies(self, candidate):
         install_requires, setup_requires = self.provider.get_pkg_reqs(candidate)
+        if install_requires is None:
+            install_requires = []
+        if setup_requires is None:
+            setup_requires = []
         deps = install_requires + setup_requires
         return deps
 
@@ -56,12 +60,15 @@ class ResolvelibResolver(Resolver):
             candidate = result.mapping[name]
             ver = candidate.ver
             install_requires, setup_requires = self.deps_provider.get_pkg_reqs(candidate)
-            prop_build_inputs = list(filter(
-                lambda name: not name.startswith('-'),
-                list({req.key for req in install_requires})))
-            build_inputs = list(filter(
-                lambda name: not name.startswith('-'),
-                list({req.key for req in setup_requires})))
+            build_inputs, prop_build_inputs = None, None
+            if install_requires is not None:
+                prop_build_inputs = list(filter(
+                    lambda name: not name.startswith('-'),
+                    list({req.key for req in install_requires})))
+            if setup_requires is not None:
+                build_inputs = list(filter(
+                    lambda name: not name.startswith('-'),
+                    list({req.key for req in setup_requires})))
             is_root = name in result.graph._forwards[None]
             nix_py_pkgs.append(ResolvedPkg(
                 name=name,


### PR DESCRIPTION
This improves the previously introduced dependency removal of packages from provider `nixpkgs`.
It was originally introduced to fight package collision issues but seemed to remove too many dependencies in many situation.
Now this mechanism gets a little more conservative. Dependencies are only removed if the dependency tree of the current package is known from the sdist DB and we can say for sure that certain dependencies is not needed.

Also inputs nixpkgs, pypi-deps-db, conda-channels are updated

fixes https://github.com/DavHau/mach-nix/issues/346
fixes https://github.com/DavHau/mach-nix/issues/330