### PR TITLE
Improve CI.

### DIFF
--- a/.github/workflows/CI_NixPy.yml
+++ b/.github/workflows/CI_NixPy.yml
@@ -10,13 +10,9 @@ on:
 jobs:
 
 ## tasks per matrix element
-  nixVersion:
-    name: Test Nix version - ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, ]
-        python-version: [3.7]
+  cli-test:
+    name: Test mach-nix cli - ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v2
@@ -45,8 +41,73 @@ jobs:
         mach-nix env ./env -r reqs.txt
       shell: bash
 
-    - name: mach-nix evaluation tests
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install/Setup - NIX
+      uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        install_url: https://releases.nixos.org/nix/nix-2.6.0/install
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          sandbox = true
+          sandbox-fallback = false
+
+    - name: mach-nix unit tests
       run: |
-        WORKERS=5 nix run .#tests-all
+        WORKERS=5 nix run .#tests-unit
+      shell: bash
+
+  eval-tests:
+    name: Eval Tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install/Setup - NIX
+      uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        install_url: https://releases.nixos.org/nix/nix-2.6.0/install
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          sandbox = true
+          sandbox-fallback = false
+
+    - name: mach-nix eval tests
+      run: |
+        WORKERS=5 nix run .#tests-eval
+      shell: bash
+
+  conda-eval-tests:
+    name: Eval Tests (with conda)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Install/Setup - NIX
+      uses: cachix/install-nix-action@v13
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        install_url: https://releases.nixos.org/nix/nix-2.6.0/install
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          sandbox = true
+          sandbox-fallback = false
+
+    - name: mach-nix eval tests
+      run: |
+        WORKERS=5 CONDA_TESTS=y nix run .#tests-eval
       shell: bash
 

--- a/.github/workflows/CI_NixPy.yml
+++ b/.github/workflows/CI_NixPy.yml
@@ -27,7 +27,7 @@ jobs:
       uses: cachix/install-nix-action@v13
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20201221_9fab14a/install
+        install_url: https://releases.nixos.org/nix/nix-2.6.0/install
         extra_nix_config: |
           experimental-features = nix-command flakes
           sandbox = true
@@ -47,8 +47,6 @@ jobs:
 
     - name: mach-nix evaluation tests
       run: |
-        wget https://github.com/DavHau/nix-portable/releases/download/v008/nix-portable
-        chmod +x nix-portable
-        WORKERS=5 ./nix-portable nix run .#tests-all
+        WORKERS=5 nix run .#tests-all
       shell: bash
 

--- a/flake.nix
+++ b/flake.nix
@@ -124,11 +124,11 @@
                   git
                   nixFlakes
                   parallel
+                  bash
                 ]
                 ++ pkgs.lib.optional (stdenv.isLinux) busybox
                 ++ pkgs.lib.optionals (stdenv.isDarwin) [
                   coreutils
-                  (pkgs.runCommand "bin-sh" {} "mkdir -p $out/bin && ln -s ${pkgs.bash}/bin/bash $out/bin/sh")
                 ])}"
 
                 cd tests

--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,6 @@
                 # busybox does).
                 ++ pkgs.lib.optionals (stdenv.isDarwin) [
                   coreutils
-                  (pkgs.runCommand "bin-sh" {} "mkdir -p $out/bin && ln -s ${pkgs.bash}/bin/bash $out/bin/sh")
                 ])}"
 
                 export PYPI_DATA=${inp.pypi-deps-db}
@@ -112,8 +111,10 @@
                   providers = { _default = [ "conda/main" "conda/r" "conda/conda-forge"]; };
                 }).condaChannelsJson}
 
+                # Use "python -m pytest" to add current directory to python path.
+                # This ensures that mach_nix is importable.
                 echo "executing unit tests"
-                pytest -n $(nproc) -x ${./.}
+                python -m pytest -n ''${WORKERS:-$(nproc)} -x ${./.}
               '');
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -132,19 +132,18 @@
                 ])}"
 
                 cd tests
-                echo "executing evaluation tests (without conda)"
+                echo "executing evaluation tests"
                 ./execute.sh
-
-                echo "executing evaluation tests (with conda)"
-                CONDA_TESTS=y ./execute.sh
               '');
             };
 
             apps.tests-all = {
               type = "app";
               program = toString (pkgs.writeScript "tests-eval" ''
+                set -e
                 ${apps.tests-unit.program}
                 ${apps.tests-eval.program}
+                CONDA_TESTS=y ${apps.tests-eval.program}
               '');
             };
 

--- a/tests/all-tests.nix
+++ b/tests/all-tests.nix
@@ -1,35 +1,8 @@
 with builtins;
 let
   mach-nix = import ../. {};
-  conda = (getEnv "CONDA_TESTS") != "";
-  makeTest = file:
-      import file ({
-        inherit mach-nix;
-      } // (if conda then (rec {
-        baseArgsMkPython = { _provierDefaults = (fromTOML (readFile ./mach_nix/provider_defaults.toml) // {
-          _default = "conda,wheel,sdist,nixpkgs";
-        }); };
-        baseArgsBuildPythonPackage = baseArgsMkPython;
-      }) else {
-        baseArgsMkPython = { _provierDefaults = fromTOML (readFile ./mach_nix/provider_defaults.toml); };
-        baseArgsBuildPythonPackage = baseArgsMkPython;
-      }));
+  lib = mach-nix.nixpkgs.lib;
+  makeTests = import ./make-tests.nix;
+  testNames = lib.mapAttrsToList (n: v: lib.removeSuffix ".nix" n) (lib.filterAttrs (n: v: lib.hasPrefix "test_" n && lib.hasSuffix ".nix" n) (builtins.readDir ./.));
 in
-flatten (map (file: makeTests) [
-  ./test_alias_dateutil.nix
-  ./test_circular_deps.nix
-  ./test_dot_in_name.nix
-  ./test_extra_pkgs.nix
-  ./test_extras.nix
-  ./test_flakes.nix
-  ./test_jupyterlab_nixpkgs.nix
-  ./test_lazy_usage.nix
-  ./test_non_python_extra_pkgs.nix
-  ./test_overrides_selectPkgs.nix
-  ./test_passthru_select_pypi_pname.nix
-  ./test_py38_cp38_wheel.nix
-  ./test_pymc3.nix
-  ./test_r_pkgs.nix
-  ./test_underscore_override.nix
-  ./test_underscore_override_extra.nix
-])
+  lib.flatten (map (name: makeTests { file = ./${name}.nix; }) testNames)

--- a/tests/execute.sh
+++ b/tests/execute.sh
@@ -1,5 +1,7 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+
+set -euxo pipefail
 
 WORKERS=${WORKERS:-10}
 
-ls ./test_* | parallel -a - -j $WORKERS --halt now,fail=1 nix-build --no-out-link --show-trace
+find . -name "test_*.nix" | parallel -a - -j "${WORKERS}" --halt now,fail=1 nix-build --no-out-link --show-trace make-tests.nix --arg file

--- a/tests/make-tests.nix
+++ b/tests/make-tests.nix
@@ -1,0 +1,18 @@
+with builtins;
+let
+  mach-nix = import ../. {};
+  lib = mach-nix.nixpkgs.lib;
+  conda = (getEnv "CONDA_TESTS") != "";
+  makeTests = {file}:
+      import file ({
+        inherit mach-nix;
+      } // (if conda then (rec {
+        baseArgsMkPython = { _providerDefaults = (fromTOML (readFile ../mach_nix/provider_defaults.toml) // {
+          _default = "conda,wheel,sdist,nixpkgs";
+        }); };
+        baseArgsBuildPythonPackage = baseArgsMkPython;
+      }) else rec {
+        baseArgsMkPython = { _providerDefaults = fromTOML (readFile ../mach_nix/provider_defaults.toml); };
+        baseArgsBuildPythonPackage = baseArgsMkPython;
+      }));
+in makeTests

--- a/tests/test_py38_cp38_wheel.nix
+++ b/tests/test_py38_cp38_wheel.nix
@@ -1,11 +1,10 @@
 {
-  mach-nix ? import ../. {
-    python = "python38";
-  },
+  mach-nix ? import ../. {},
   ...
 }:
 with builtins;
 mach-nix.mkPython {
+  python = "python38";
   requirements = ''
     numba==0.50.1
   '';


### PR DESCRIPTION
- Don't use a prerelease version of nix in CI (and stop installing two different copies of nix).
- Split CI into multiple jobs, to improve end-to-end time. This also, incidentally, ensures that tests don't fail silently.
- Start running the tests with conda as a provider in CI.
  - It looks like this was accidentally removed in 9463ccc8c7a5ce085d3cea36685d6b58d9bc90e0 which landed as part of #285.
- Fix the invocation of unit-tests in CI, which was failing silently.