### PR TITLE
Add aarch64-darwin to the system map for conda channels. Fix darwin manylinux logic. Fix deptree NoneType + NoneType

### DIFF
--- a/mach_nix/nix/conda-channels.nix
+++ b/mach_nix/nix/conda-channels.nix
@@ -17,6 +17,7 @@ let
   systemMap = {
     x86_64-linux = "linux-64";
     x86_64-darwin = "osx-64";
+    aarch64-darwin = "osx-arm64";
     aarch64-linux = "linux-aarch64";
   };
 

--- a/mach_nix/nix/lib.nix
+++ b/mach_nix/nix/lib.nix
@@ -179,7 +179,7 @@ rec {
       file = "${compileExpression args}/share/mach_nix_file.nix";
       result = import file { inherit (args) pkgs python; };
       manylinux =
-        if args.pkgs.stdenv.hostPlatform.system == "x86_64-darwin" then
+        if builtins.elem args.pkgs.stdenv.hostPlatform.system [ "x86_64-darwin" "aarch64-darwin" ] then
           []
         else
           args.pkgs.pythonManylinuxPackages.manylinux1;


### PR DESCRIPTION
Adds some aarch64-darwin compatibility fixes that I ran into on our own code.

The deptree thing would result in an error like #396 

```
   ....

  File "/nix/store/585x19x0hkzvnd6nai6ag5hpnl8zajh1-jrpk0l8ad8wrak6yhgfmraddnpia4vpd-source/mach_nix/deptree.py", line 78, in name
    if indexed_pkgs[node_name].build_inputs + indexed_pkgs[node_name].prop_build_inputs == []:
TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
```

Fixes #396 

Let's see if this also fixes the odd conda errors in CI.