### PR TITLE
WIP: Use pep517 to extract metadata.

### DIFF
--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -114,8 +114,8 @@ let
         echo "extracting metadata for python${v}"
         ${extract-cmd {
           inherit python src;
-          providers = { _defaults = "wheel,sdist"; };
-          _providerDefaults = {};
+          providers = {};
+          _providerDefaults = { _default = "wheel,sdist"; setuptools = "nixpkgs"; wheel = "nixpkgs"; };
         } "$out/python${v}.json"} &> $out/python${v}.log
       ''
     ))}

--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -2,10 +2,10 @@
   pkgs ? import <nixpkgs> { config = { allowUnfree = true; };},
   lib ? pkgs.lib,
   pythonInterpreters ? pkgs.useInterpreters or (with pkgs; [
-    python35
-    python36
     python37
     python38
+    python39
+    python310
   ]),
   # Only used for extractor-fast
   condaDataRev ? (builtins.fromJSON (builtins.readFile ../../mach_nix/nix/CONDA_CHANNELS.json)).rev,
@@ -115,6 +115,7 @@ let
         ${extract-cmd {
           inherit python src;
           providers = { _defaults = "wheel,sdist"; };
+          _providerDefaults = {};
         } "$out/python${v}.json"} &> $out/python${v}.log
       ''
     ))}

--- a/lib/extractor/fast-extractor.nix
+++ b/lib/extractor/fast-extractor.nix
@@ -1,1 +1,1 @@
-(import ./default.nix {}).extractor-fast
+{...}@args: (import ./default.nix args).extractor-fast

--- a/lib/extractor/fast-extractor.nix
+++ b/lib/extractor/fast-extractor.nix
@@ -1,1 +1,1 @@
-{...}@args: (import ./default.nix args).extractor-fast
+{pypiData, argsJSON}: (import ./default.nix { inherit pypiData; } ).extractor-fast (builtins.fromJSON argsJSON)

--- a/lib/extractor/make-drvs.nix
+++ b/lib/extractor/make-drvs.nix
@@ -1,1 +1,1 @@
-(import ./default.nix {}).make-drvs
+{...}@args: (import ./default.nix args).make-drvs

--- a/mach_nix/nix/buildPythonPackage.nix
+++ b/mach_nix/nix/buildPythonPackage.nix
@@ -35,10 +35,10 @@ let
       # Extract dependencies automatically if 'requirements' is unset
       pname =
         if hasAttr "pname" args then args.pname
-        else extract-meta python_pkg src "name" "pname";
+        else extract-meta { inherit python providers overridesPre src; } src "name" "pname";
       version =
         if hasAttr "version" args then args.version
-        else extract-meta python_pkg src "version" "version";
+        else extract-meta { inherit python providers overridesPre src; } src "version" "version";
       meta_reqs = extract-requirements { inherit python providers overridesPre src; } "${pname}:${version}" extras;
       reqs =
         (if requirements == "" then

--- a/mach_nix/nix/buildPythonPackage.nix
+++ b/mach_nix/nix/buildPythonPackage.nix
@@ -5,6 +5,10 @@ with pkgs.lib;
 let
   l = import ./lib.nix { inherit (pkgs) lib; inherit pkgs; };
 
+  inherit (import ./extract-metadata.nix {
+    inherit condaChannelsExtra condaDataRev condaDataSha256 pkgs pypiData;
+   }) extract-meta extract-requirements;
+
   buildPythonPackageBase = pythonGlobal: func:
     args@{
       cudaVersion ? pkgs.cudatoolkit.version,  # max allowed cuda version for conda packages
@@ -24,7 +28,6 @@ let
       _fixes ? import ../fixes.nix {pkgs = pkgs;},
       ...
     }:
-    with (_buildPythonParseArgs args);
     with builtins;
     let
       python_pkg = l.selectPythonPkg pkgs python requirements;
@@ -32,17 +35,13 @@ let
       # Extract dependencies automatically if 'requirements' is unset
       pname =
         if hasAttr "pname" args then args.pname
-        else l.extract_meta python_pkg src "name" "pname";
+        else extract-meta python_pkg src "name" "pname";
       version =
         if hasAttr "version" args then args.version
-        else l.extract_meta python_pkg src "version" "version";
-      meta_reqs = l.extract_requirements python_pkg src "${pname}:${version}" extras;
+        else extract-meta python_pkg src "version" "version";
+      meta_reqs = extract-requirements { inherit python providers overridesPre src; } "${pname}:${version}" extras;
       reqs =
         (if requirements == "" then
-          if builtins.hasAttr "format" args && args.format != "setuptools" then
-            throw "Automatic dependency extraction is only available for 'setuptools' format."
-                  " Please specify 'requirements' if setuptools is not used."
-          else
             meta_reqs
         else
           requirements)
@@ -64,7 +63,6 @@ let
       pass_args = removeAttrs args (builtins.attrNames ({
         inherit condaDataRev condaDataSha256 overridesPre overridesPost pkgs providers
                 requirements requirementsExtra pypiData tests _providerDefaults _ ;
-        python = python_arg;
       }));
     in
     py_final.pkgs."${func}" ( pass_args // {

--- a/mach_nix/nix/compileOverrides.nix
+++ b/mach_nix/nix/compileOverrides.nix
@@ -75,4 +75,4 @@ let
     '';
 in
 # single file derivation containing $out/share/mach_nix_file.nix
-mach_nix_file
+traceValFn (drv: "${drv.outPath} ${python}") mach_nix_file

--- a/mach_nix/nix/extract-metadata.nix
+++ b/mach_nix/nix/extract-metadata.nix
@@ -1,0 +1,79 @@
+{ condaChannelsExtra, condaDataRev, condaDataSha256, pkgs, pypiData, ... }:
+with builtins;
+with pkgs.lib;
+let
+  l = import ./lib.nix { inherit (pkgs) lib; inherit pkgs; };
+
+  mkPython = (import ./mkPython.nix {
+    inherit condaChannelsExtra condaDataRev condaDataSha256 pkgs pypiData;
+  });
+  default-build-system = {
+    requires = ["setuptools >= 40.8.0" "wheel"];
+    build-backend = "setuptools.build_meta:__legacy__";
+  };
+
+  extract-cmd = {python, src, providers, overridesPre}: outPath:
+    let
+      pyproject-toml = "${src}/pyproject.toml";
+      build-system = if builtins.pathExists pyproject-toml then
+          let
+            toml = builtins.fromTOML (builtins.readFile pyproject-toml);
+          in toml.build-system
+        else default-build-system;
+      base-env = mkPython python {
+        inherit python providers;
+        requirements = ''
+          pep517
+          importlib-metadata >= 4.0.0
+        '';
+      };
+      build-env = mkPython python {
+        inherit python providers overridesPre;
+        requirements = concatStringsSep "\n" build-system.requires;
+      };
+      args = escapeShellArgs [build-env.interpreter build-system.build-backend build-system.backend-path or ""];
+    in 
+      ''
+      ${base-env.interpreter} ${./extract-metadata.py} ${outPath} ${src} ${args}
+      '';
+
+    extract = {python, src, providers, overridesPre}@args: fail_msg:
+      let
+        result = pkgs.runCommand "python-metadata" {} ''
+          mkdir $out
+          ${extract-cmd args "$out/python.json"}
+        '';
+        file_path = traceVal "${result}/python.json";
+      in
+        if pathExists file_path then fromJSON (readFile file_path) else throw fail_msg;
+
+    extract-requirements = {python, src, providers, overridesPre}@args: name: extras:
+      let
+        ensureList = requires: if isString requires then [requires] else requires;
+        data = extract args ''
+          Automatic requirements extraction failed for ${name}.
+          Please manually specify 'requirements' '';
+        setup_requires = if hasAttr "setup_requires" data then ensureList data.setup_requires else [];
+        install_requires = if hasAttr "requires_dist" data then ensureList data.requires_dist else [];
+        extras_require =
+          if hasAttr "extras_require" data then
+            flatten (map (extra: data.extras_require."${extra}") extras)
+          else [];
+        all_reqs = l.concat_reqs (setup_requires ++ install_requires ++ extras_require);
+        msg = "\n automatically detected requirements of ${name} ${version}:${all_reqs}\n\n";
+      in
+        trace msg all_reqs;
+
+    extract-meta = {python, src, providers, overridesPre}@args: attr: for_attr:
+      let
+        error_msg = ''
+          Automatic extraction of '${for_attr}' from python package source ${src} failed.
+          Please manually specify '${for_attr}' '';
+        data = extract args error_msg;
+        result = if hasAttr attr data then data."${attr}" else throw error_msg;
+        msg = "\n automatically detected ${for_attr}: '${result}'";
+      in
+        trace msg result;
+in {
+  inherit extract-cmd extract-meta extract-requirements;
+}

--- a/mach_nix/nix/extract-metadata.py
+++ b/mach_nix/nix/extract-metadata.py
@@ -4,12 +4,20 @@ import sys
 from importlib_metadata import Distribution
 from pep517.wrappers import Pep517HookCaller
 
-_, out, source, python, backend, backend_path = sys.argv
+_, out, source, python, backend, backend_path, command, *args = sys.argv
 
 hooks = Pep517HookCaller(
     source, build_backend=backend, python_executable=python, backend_path=backend_path
 )
-dist = Distribution.at(hooks.prepare_metadata_for_build_wheel("."))
+if command == "build-requires":
+    output = hooks.get_requires_for_build_wheel()
+elif command == "metadata":
+    dist = Distribution.at(hooks.prepare_metadata_for_build_wheel("."))
+    (build_requires_path,) = args
+    with open(build_requires_path) as f:
+        build_requires = json.load(f)
+    output = dist.metadata.json
+    output["build-requires"] = build_requires
 
 with open(out, "x") as f:
-    json.dump(dist.metadata.json, f)
+    json.dump(output, f)

--- a/mach_nix/nix/extract-metadata.py
+++ b/mach_nix/nix/extract-metadata.py
@@ -1,0 +1,15 @@
+import json
+import sys
+
+from importlib_metadata import Distribution
+from pep517.wrappers import Pep517HookCaller
+
+_, out, source, python, backend, backend_path = sys.argv
+
+hooks = Pep517HookCaller(
+    source, build_backend=backend, python_executable=python, backend_path=backend_path
+)
+dist = Distribution.at(hooks.prepare_metadata_for_build_wheel("."))
+
+with open(out, "x") as f:
+    json.dump(dist.metadata.json, f)

--- a/mach_nix/nix/lib.nix
+++ b/mach_nix/nix/lib.nix
@@ -77,7 +77,9 @@ rec {
          else
           throw '''python' must be a string. Example: "python38"'');
     in
-      if preProcessedReqs ? python then
+      if isDerivation pyStr then
+        pyStr
+      else if preProcessedReqs ? python then
         if ! isNull pyStr && pyStr != preProcessedReqs.python then
           throw ''
             The specified 'python' conflicts the one specified via 'requirements'.


### PR DESCRIPTION
I'm leaving this branch with my work-in-progress for using pep517 (both the package and the PEP) to extract package metadata, instead of a patch setuptools. In particular, this should work with more packages.

An incomplete list of things that still need to be done:

- [ ] Properly parse `requires-dist` (since this includes the equivalent of the old `install_requires` *and* `extra_requires`). This should perhaps be done in the python, before writing out the metadata.
  - This might not be necessary, as https://github.com/DavHau/mach-nix/blob/c914064c9b8cab9495818ffe8d834d8c2c1d7ce7/mach_nix/data/providers.py#L473 process markers in `install_requires`.
  - On the other hand [this code](https://github.com/DavHau/mach-nix/blob/master/mach_nix/nix/lib.nix#L207-L222) (and the copy of that code in `mach_nix/nix/extract-metadata.nix`) doesn't handle markers (in particular, `extra` markers) which is a bug (related to #190).
- [ ] Provide code paths for use by [pypi-deps-db](https://github.com/DavHau/pypi-deps-db).
- [ ] Provide code paths for use by flake's `extract-reqs`.
- [ ] Remove obsolete code.
  - Most of the code in `lib/extractor/default.nix` is unused after this PR.
- [ ] Decide on whether to drop python2 support. If so, document that change; if not, provide fallback code to handle that case.
  - I think it might be possible to still support python2 by using python3 for the `base-env` environment in `mach_nix/nix/extract-metadata.nix` but python2 for the `metadata-env` and `build-env`.
- [ ] ....