### PR TITLE
Add a nix version check.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,8 @@
 with builtins;
 with pkgs.lib;
 
+assert builtins.compareVersions builtins.nixVersion "2.3" >= 0;
+
 let
   l = import ./mach_nix/nix/lib.nix { inherit pkgs; lib = pkgs.lib; };
 


### PR DESCRIPTION
Fixes #385.

This check might be broken by https://github.com/NixOS/nix/issues/5970 in the future. (Although the suggestion in https://github.com/NixOS/nix/pull/5971#issuecomment-1021695124) would address that in new enough versions of nix.)