### PR TITLE
Don't die on use of Provides-Extra

### DIFF
--- a/mach_nix/requirements.py
+++ b/mach_nix/requirements.py
@@ -54,7 +54,10 @@ def filter_reqs_by_eval_marker(reqs: Iterable[Requirement], context: dict, selec
                 if distlib.markers.interpret(str(req.marker), extra_context):
                     yield req
         else:
-            if distlib.markers.interpret(str(req.marker), context):
+            extra_context = context.copy()
+            if 'extra' not in extra_context:
+                extra_context['extra'] = None
+            if distlib.markers.interpret(str(req.marker), extra_context):
                 yield req
 
 


### PR DESCRIPTION
[Disclaimer: first time digging into mach-nix internals, I don't know what I'm doing.]

I came across a wheel package
(https://download.pytorch.org/whl/cpu/torchvision-0.11.1%2Bcpu-cp36-cp36m-linux_x86_64.whl)
with this METADATA file snippet:

```
  Provides-Extra: scipy
  Requires-Dist: scipy ; extra == 'scipy'
```

Extracting the Requires-Dist: fields and passing them to mach-nix (minimal repro):

```
  mach-nix.mkPython {
    requirements = ''
      scipy; extra == 'scipy'
    '';
  }
```

results in a crash:

```
  [...traceback...]
    File "/nix/store/sm2vgf8ddyw8d81j04lwgb17q8pmp39h-python3-3.9.9-env/lib/python3.9/site-packages/distlib/markers.py", line 69, in evaluate
      raise SyntaxError('unknown variable: %s' % expr)
  SyntaxError: unknown variable: extra
```

This patch adds a fallback value for 'extra' (None) if there is no prior
definition, preventing the crash.

More info about the Provides-Extra feature here:
https://packaging.python.org/en/latest/specifications/core-metadata/#provides-extra-multiple-use