### PR TITLE
fix-package: pyjq needs nativeBuildInputs

### DIFF
--- a/mach_nix/fixes.nix
+++ b/mach_nix/fixes.nix
@@ -103,6 +103,11 @@ rec {
     patches.mod = oldPatches: filterSafe (patch: ! hasSuffix "reproducible.patch" patch) oldPatches;
   };
 
+  pyjq.add-native-inputs = {
+    _cond = { prov, ver, ... }: prov == "sdist";
+    nativeBuildInputs.add = with pkgs; [ autoconf automake libtool ];
+  };
+
   rpy2.remove-pandas-patch = {
     _cond = { prov, ver, ... }:
       # https://github.com/rpy2/rpy2/commit/fbd060e364b70012e8d26cc74df04ee53f769379


### PR DESCRIPTION
Without this the package fails to build. (It is only distributed as a tarball for non-macOS it seems.)