### PR TITLE
Remove pipenv from dependency extractor derivation

### DIFF
--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -117,7 +117,7 @@ let
     out_file=$out/python.json ${py}/bin/python -c "${setuptools_shim}" install &> $out/python.log || true
   '';
   base_derivation = pyVersions: with pkgs; {
-    buildInputs = [ unzip pkg-config pipenv ];
+    buildInputs = [ unzip pkg-config ];
     phases = ["unpackPhase" "installPhase"];
     # Tells our modified python builtins to dump setup attributes instead of doing an actual installation
     dump_setup_attrs = "y";


### PR DESCRIPTION
[I don't see a way to adapt pipenv to the python version the user asked for, since some use of base_derivation is used by _multiple_ python versions. Hence I think it's better to remove pipenv.]

This fixes automatic dependency extraction from packages when the user
asks for a python version that differs too much from the default python
in nixpkgs (which pipenv was built with).

Fixes https://github.com/DavHau/mach-nix/issues/426.