### PR TITLE
Replace --suffix-each with multiple --suffix options

### DIFF
--- a/mach_nix/nix/mkPython.nix
+++ b/mach_nix/nix/mkPython.nix
@@ -126,10 +126,9 @@ let
       });
       final_env = py_final_with_pkgs.override (oa: {
         inherit ignoreCollisions;
-        makeWrapperArgs = [
-          ''--suffix-each PATH ":" "${toString (map (p: "${p}/bin") extra_pkgs_other)}"''
-          ''--set QT_PLUGIN_PATH ${py_final_with_pkgs}/plugins''
-        ];
+        makeWrapperArgs =
+          (map (p: "--suffix PATH : ${p}/bin") extra_pkgs_other)
+          ++ [''--set QT_PLUGIN_PATH ${py_final_with_pkgs}/plugins''];
       });
     in let
       self = final_env.overrideAttrs (oa: {


### PR DESCRIPTION
Since
https://github.com/NixOS/nixpkgs/commit/7f802c704651baba3adb2abdd9cc6645c987b9ad
using --suffix-each in makeWrapperArgs is no longer supported and breaks
like this:

```
  $ nix-build ./any-mach-nix-env-with-latest-nixpkgs.nix
  [...]
  <stdin>: In function 'main':
  <stdin>:9:6: error: #error makeCWrapper: Unknown argument --suffix-each
  <stdin>:10:6: error: #error makeCWrapper: Unknown argument PATH
  <stdin>:11:6: error: #error makeCWrapper: Unknown argument :
  <stdin>:12:6: error: #error makeCWrapper: Unknown argument
  builder for '/nix/store/41713mrzrqlq12kgfgcx10wmdvmkfh7k-python3-3.9.12-env.drv' failed with exit code 1
```

So replace it with multiple --suffix args, which the new
makeBinaryWrapper/makeCWrapper program supports (and is compatible with
the old makeWrapper).

Fixes https://github.com/DavHau/mach-nix/issues/444.