### PR TITLE
Fix regex for 2-digit minor python version

### DIFF
--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -291,21 +291,21 @@ class WheelDependencyProvider(DependencyProviderBase):
         cp_abi = f"cp{maj}{min}mu" if int(maj) == 2 else f"cp{maj}{min}m?"
         if self.system == "linux":
             self.preferred_wheels = (
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux2014_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux2010_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux1_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux_2_5_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux_2_12_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-manylinux_2_17_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-linux_{self.platform}"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-any"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-manylinux2014_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-manylinux2010_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-manylinux1_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-manylinux_2_5_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-manylinux_2_12_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-manylinux_2_17_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-linux_{self.platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-any"),
             )
         elif self.system == "darwin":
             platform = "arm64" if self.platform == "aarch64" else self.platform
             self.preferred_wheels = (
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-any"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_universal"),
-                re.compile(rf".*(py{maj}|cp{maj}){min}?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_{platform}"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-any"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_universal"),
+                re.compile(rf".*(py{maj}|cp{maj})({min})?[\.-].*({cp_abi}|abi3|none)-macosx_\d*_\d*_{platform}"),
             )
         else:
             raise Exception(f"Unsupported Platform {platform.system()}")

--- a/mach_nix/tests/test_providers.py
+++ b/mach_nix/tests/test_providers.py
@@ -20,6 +20,7 @@ from mach_nix.versions import PyVer
     # none-any wheels for py2 + py3
     (True, '2.7.0', 'requests-2.24.0-py2.py3-none-any.whl', "linux", "x86_64"),
     (True, '3.8.0', 'requests-2.24.0-py2.py3-none-any.whl', "linux", "x86_64"),
+    (True, '3.10.4', 'requests-2.24.0-py2.py3-none-any.whl', "linux", "x86_64"),
     (False, '4.0.0', 'requests-2.24.0-py2.py3-none-any.whl', "linux", "x86_64"),
     # none-any wheels for py2
     (True, '2.0.0', 'requests-2.24.0-py2-none-any.whl', "linux", "x86_64"),


### PR DESCRIPTION
This PR fixes a bug in regex in `WheelDependencyProvider`. This bug prevented mach-nix from using some wheels for python version 3.10 (and higher). For example, instead of 

```
coloredlogs - 15.0.1 - wheel - py2.py3-none-any
└── humanfriendly - 10.0 - wheel - py2.py3-none-any
```

It would choose
```
coloredlogs - 15.0.1 - sdist
└── humanfriendly - 10.0 - sdist
```

Because mach-nix is unable to build some packages from source, this bug was the only thing that prevented me from upgrading to python 3.10 in my project.