### PR TITLE
chore: accept newer python versions

### DIFF
--- a/mach_nix/run.py
+++ b/mach_nix/run.py
@@ -171,9 +171,9 @@ def github_rev_and_sha256(owner, repo, ref):
 def parse_args(parser: ArgumentParser, nixpkgs_ref):
     common_arguments = (
         (('-p', '--python'), dict(
-            help='select python version (default: 3.7)',
-            choices=('2.7', '3.5', '3.6', '3.7', '3.8'),
-            default='3.7')),
+            help='select python version (default: 3.9)',
+            choices=('2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10'),
+            default='3.9')),
 
         (('-r',), dict(
             help='path to requirements.txt file',


### PR DESCRIPTION
The PR adds options to the argument parser that allow the user to specify Python versions 3.9 and 3.10. It also changes the default to 3.9 (from 3.7). 

closes #356 