### PR TITLE
Fix `nix (build|shell) mach-nix#gen`

### DIFF
--- a/mach_nix/nix/withDot.nix
+++ b/mach_nix/nix/withDot.nix
@@ -10,7 +10,7 @@ let
       };
       attrs_list = map (n:
           { name = n; value = (gen attr (selected ++ [n])); }
-      ) names;
+      ) (filter (n: n!= "meta") names);
       drv = if attr == "" then pyEnvBase else pyEnvBase."${attr}";
       pyEnv = drv.overrideAttrs (oa: {
         passthru =


### PR DESCRIPTION
`nix (build|shell) mach-nix#gen` is broken on recent nix versions because
of https://github.com/NixOS/nix/issues/6690.

This commit fixes it by removing `meta` from the list of handled packages.
As a result, nix can access the derivation's meta as expected, and work
as expected.

The side effect is that the `meta` package on pypi cannot be used, but
that's a cost we have to pay.