### PR TITLE
fix: typos

### DIFF
--- a/mach_nix/data/providers.py
+++ b/mach_nix/data/providers.py
@@ -495,8 +495,8 @@ def conda_virtual_packages():
     )
 
     # platform.libc_ver() returns ('', '') on macOS and MACHNIX_GLIBC_VERSION is unset
-    libc_complier, libc_version = platform.libc_ver()
-    if libc_complier == 'glibc':
+    libc_compiler, libc_version = platform.libc_ver()
+    if libc_compiler == 'glibc':
         packages['__glibc'] = environ.get("MACHNIX_GLIBC_VERSION", libc_version)
 
     # Maximum version of CUDA supported by the display driver.

--- a/mach_nix/nix/buildPythonPackage.nix
+++ b/mach_nix/nix/buildPythonPackage.nix
@@ -10,7 +10,7 @@ let
       cudaVersion ? pkgs.cudatoolkit.version,  # max allowed cuda version for conda packages
       ignoreDataOutdated ? false,  # don't fail if pypi data is older than nixpkgs
       requirements ? "",  # content from a requirements.txt file
-      requirementsExtra ? "",  # add additional requirements to the packge
+      requirementsExtra ? "",  # add additional requirements to the package
       tests ? false,  # Disable tests wherever possible to decrease build time.
       extras ? [],
       doCheck ? tests,

--- a/mach_nix/nix/mkPython.nix
+++ b/mach_nix/nix/mkPython.nix
@@ -60,7 +60,7 @@ let
       extra_pkgs_r = filter (p: p ? rCommand) packagesExtra;
       extra_pkgs_other = filter (p: ! (p ? rCommand || p ? pythonModule || l.is_src p)) packagesExtra;
 
-      # gather requirements of exra pkgs
+      # gather requirements of extra pkgs
       extra_pkgs_py_reqs =
         map (p:
           if hasAttr "requirements" p then p.pname

--- a/mach_nix/resolver/__init__.py
+++ b/mach_nix/resolver/__init__.py
@@ -19,7 +19,7 @@ class ResolvedPkg(JSONEncoder):
     is_root: bool
     provider_info: ProviderInfo
     extras_selected: List[str]
-    # contains direct or indirect children wich have been diconnected due to circular deps
+    # contains direct or indirect children which have been disconnected due to circular deps
     removed_circular_deps: Set[str] = field(default_factory=set)
     build: str = None
 


### PR DESCRIPTION
I saw some typo while using `mach-nix`, but I think that particular one is fixed already, in the process of looking some came up:

Fixes some trivial typos, mostly in comments,
except for in `mach_nix/resolver/__init__.py`,
the scope is a context manager, so there shouldn't be arbitrary sideffects by the rename.