### PR TITLE
unthinkingly substitute the new fetcher everywhere

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -209,8 +209,8 @@ Mach-nix supports multiple providers to retrieve python packages from. The user 
 ### File resolution
 With `pypi-deps-db`, we have built a dependency graph, where each package is defined by name and version, for example `pillow-9.1.0`.
 
-To download a package, we need it's URL and hash. This is where [nix-pypi-fetcher](https://github.com/DavHau/nix-pypi-fetcher) comes in.
-`nix-pypi-fetcher` is another database, which allows us to resolve packages to their URL and hash.
+To download a package, we need it's URL and hash. This is where [nix-pypi-fetcher-2](https://github.com/DavHau/nix-pypi-fetcher-2) comes in.
+`nix-pypi-fetcher-2` is another database, which allows us to resolve packages to their URL and hash.
 
 For details, see [implementation.md](implementation.md).
 

--- a/implementation.md
+++ b/implementation.md
@@ -1,6 +1,6 @@
 ## File resolution
 
-`mach-nix` uses [nix-pypi-fetcher](https://github.com/DavHau/nix-pypi-fetcher) to translate package versions to URLs and hashes.
+`mach-nix` uses [nix-pypi-fetcher-2](https://github.com/DavHau/nix-pypi-fetcher-2) to translate package versions to URLs and hashes.
 
 For example, the declaration "package pillow + version 9.1.0 + python 3.9 + linux" resolves to
 

--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -15,8 +15,8 @@ with lib;
 let
   commit = "1434cc0ee2da462f0c719d3a4c0ab4c87d0931e7";
   fetchPypiSrc = builtins.fetchTarball {
-   name = "nix-pypi-fetcher";
-   url = "https://github.com/DavHau/nix-pypi-fetcher/archive/${commit}.tar.gz";
+   name = "nix-pypi-fetcher-2";
+   url = "https://github.com/DavHau/nix-pypi-fetcher-2/archive/${commit}.tar.gz";
    # Hash obtained using `nix-prefetch-url --unpack <url>`
    sha256 = "080l189zzwrv75jgr7agvs4hjv4i613j86d4qky154fw5ncp0mnp";
   };
@@ -64,7 +64,7 @@ let
         rm ${site_pkgs_dir}/setuptools
         mv ${site_pkgs_dir}/setuptools_tmp ${site_pkgs_dir}/setuptools
         # patch setuptools/__init__.py
-        echo ${site_pkgs_dir}/setuptools/__init__.py 
+        echo ${site_pkgs_dir}/setuptools/__init__.py
         patch ${site_pkgs_dir}/setuptools/__init__.py ${./setuptools.patch}
         # remove .pyc files
         if [ ${major} = 2 ]; then
@@ -162,7 +162,7 @@ rec {
   inherit machnix_source mkPy pythonInterpreters;
   example = extractor {pkg = "requests"; version = "2.22.0";};
   extract_from_src = {py, src}:
-    let 
+    let
       py' = if isString py then pkgs."${py}" else py;
     in
     stdenv.mkDerivation ( (base_derivation []) // {

--- a/mach_nix/generators/overides_generator.py
+++ b/mach_nix/generators/overides_generator.py
@@ -46,8 +46,8 @@ class OverridesGenerator(ExpressionGenerator):
             with pkgs.lib;
             let
               pypi_fetcher_src = builtins.fetchTarball {{
-                name = "nix-pypi-fetcher";
-                url = "https://github.com/DavHau/nix-pypi-fetcher/tarball/{self.pypi_fetcher_commit}";
+                name = "nix-pypi-fetcher-2";
+                url = "https://github.com/DavHau/nix-pypi-fetcher-2/tarball/{self.pypi_fetcher_commit}";
                 # Hash obtained using `nix-prefetch-url --unpack <url>`
                 sha256 = "{self.pypi_fetcher_sha256}";
               }};

--- a/mach_nix/nix/deps-db-and-fetcher.nix
+++ b/mach_nix/nix/deps-db-and-fetcher.nix
@@ -14,7 +14,7 @@ let
   pypi_fetcher_sha256 = removeSuffix "\n" (readFile "${deps_db_src}/PYPI_FETCHER_SHA256");
   pypi_fetcher_src = fetchTarball {
     name = "nix-pypi-fetcher-src";
-    url = "https://github.com/DavHau/nix-pypi-fetcher/tarball/${pypi_fetcher_commit}";
+    url = "https://github.com/DavHau/nix-pypi-fetcher-2/tarball/${pypi_fetcher_commit}";
     sha256 = "${pypi_fetcher_sha256}";
   };
   pypi_fetcher = import pypi_fetcher_src {

--- a/pypi-crawlers/Readme.md
+++ b/pypi-crawlers/Readme.md
@@ -4,7 +4,7 @@ These crawlers have been created for the purpose of maintaining data required fo
 
 This project contains 2 crawlers. One which indexes available `sdist` python package downloads from pypi.org and another one which actually downloads all packages and extracts their dependency information.
 
-The URL index is stored here: [nix-pypi-fetcher](https://github.com/DavHau/nix-pypi-fetcher) (which at the same time is a convenient standalone pypi fetcher for nix)  
+The URL index is stored here: [nix-pypi-fetcher-2](https://github.com/DavHau/nix-pypi-fetcher-2) (which at the same time is a convenient standalone pypi fetcher for nix)
 The dependency graph is stored here: [pypi-deps-db](https://github.com/DavHau/pypi-deps-db)
 
 ---

--- a/pypi-crawlers/nix/crawler/configuration.nix
+++ b/pypi-crawlers/nix/crawler/configuration.nix
@@ -112,7 +112,7 @@ in
       path = [ python pkgs.git ];
       script = with environment; ''
         set -x
-        ${cd_into_updated_proj_branch "nix-pypi-fetcher" "nix-pypi-fetcher_update" "${branch}" EMAIL}
+        ${cd_into_updated_proj_branch "nix-pypi-fetcher-2" "nix-pypi-fetcher_update" "${branch}" EMAIL}
         rm -f ./pypi/*
         ${python}/bin/python -u ${src}/crawl_urls.py ./pypi
         echo $(date +%s) > UNIX_TIMESTAMP
@@ -140,7 +140,7 @@ in
         DB_HOST = db_host;
         EMAIL = "hsngrmpf+pypidepscrawler@gmail.com";
         CLEANUP = "y";
-        pypi_fetcher = "/home/${user}/nix-pypi-fetcher";
+        pypi_fetcher = "/home/${user}/nix-pypi-fetcher-2";
         inherit extractor_dir;
       };
     in
@@ -154,13 +154,13 @@ in
       ${python}/bin/python -u ${src}/crawl_sdist_deps.py
       set -x
       export GIT_SSH_COMMAND="${pkgs.openssh}/bin/ssh -i /home/${user}/.ssh/id_ed25519_deps_db"
-      ${cd_into_updated_proj_branch "nix-pypi-fetcher" "nix-pypi-fetcher" "${branch}" EMAIL}
+      ${cd_into_updated_proj_branch "nix-pypi-fetcher-2" "nix-pypi-fetcher-2" "${branch}" EMAIL}
       ${cd_into_updated_proj_branch "pypi-deps-db" "pypi-deps-db" "${branch}" EMAIL}
       rm -f ./sdist/*
       ${python}/bin/python -u ${src}/dump_sdist_deps.py ./sdist
       echo $(date +%s) > UNIX_TIMESTAMP
-      pypi_fetcher_commit=$(git ls-remote https://github.com/DavHau/nix-pypi-fetcher ${branch} | awk '{print $1;}')
-      pypi_fetcher_url="https://github.com/DavHau/nix-pypi-fetcher/archive/''${pypi_fetcher_commit}.tar.gz"
+      pypi_fetcher_commit=$(git ls-remote https://github.com/DavHau/nix-pypi-fetcher-2 ${branch} | awk '{print $1;}')
+      pypi_fetcher_url="https://github.com/DavHau/nix-pypi-fetcher-2/archive/''${pypi_fetcher_commit}.tar.gz"
       pypi_fetcher_hash=$(nix-prefetch-url --unpack $pypi_fetcher_url)
       echo $pypi_fetcher_commit > PYPI_FETCHER_COMMIT
       echo $pypi_fetcher_hash > PYPI_FETCHER_SHA256
@@ -187,7 +187,7 @@ in
         WORKERS = "5";
         PYTHONPATH = src;
         EMAIL = "hsngrmpf+pypidepscrawler@gmail.com";
-        pypi_fetcher = "/home/${user}/nix-pypi-fetcher";
+        pypi_fetcher = "/home/${user}/nix-pypi-fetcher-2";
         dump_dir = "/home/${user}/pypi-deps-db/wheel";
       };
     in
@@ -199,13 +199,13 @@ in
     script = with environment; ''
       set -x
       export GIT_SSH_COMMAND="${pkgs.openssh}/bin/ssh -i /home/${user}/.ssh/id_ed25519_deps_db"
-      ${cd_into_updated_proj_branch "nix-pypi-fetcher" "nix-pypi-fetcher" "${branch}" EMAIL}
+      ${cd_into_updated_proj_branch "nix-pypi-fetcher-2" "nix-pypi-fetcher" "${branch}" EMAIL}
       ${cd_into_updated_proj_branch "pypi-deps-db" "pypi-deps-db" "${branch}" EMAIL}
       export PYTONPATH=${src}
       ${python}/bin/python -u ${src}/crawl_wheel_deps.py $dump_dir
       echo $(date +%s) > UNIX_TIMESTAMP
-      pypi_fetcher_commit=$(git ls-remote https://github.com/DavHau/nix-pypi-fetcher ${branch} | awk '{print $1;}')
-      pypi_fetcher_url="https://github.com/DavHau/nix-pypi-fetcher/archive/''${pypi_fetcher_commit}.tar.gz"
+      pypi_fetcher_commit=$(git ls-remote https://github.com/DavHau/nix-pypi-fetcher-2 ${branch} | awk '{print $1;}')
+      pypi_fetcher_url="https://github.com/DavHau/nix-pypi-fetcher-2/archive/''${pypi_fetcher_commit}.tar.gz"
       pypi_fetcher_hash=$(nix-prefetch-url --unpack $pypi_fetcher_url)
       echo $pypi_fetcher_commit > PYPI_FETCHER_COMMIT
       echo $pypi_fetcher_hash > PYPI_FETCHER_SHA256

--- a/pypi-crawlers/nix/power-wheels-crawler/configuration.nix
+++ b/pypi-crawlers/nix/power-wheels-crawler/configuration.nix
@@ -38,19 +38,19 @@ in
       WORKERS = "100";
       PYTHONPATH = src;
       EMAIL = "hsngrmpf+pypidepscrawler@gmail.com";
-      pypi_fetcher = "/home/${user}/nix-pypi-fetcher";
+      pypi_fetcher = "/home/${user}/nix-pypi-fetcher-2";
       dump_dir = "/home/${user}/wheels";
       #skip = "21";
     };
     path = [ python pkgs.git ];
     script = ''
-      if [ ! -e /home/${user}/nix-pypi-fetcher ]; then
-        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher.git /home/${user}/nix-pypi-fetcher
-        cd /home/${user}/nix-pypi-fetcher
+      if [ ! -e /home/${user}/nix-pypi-fetcher-2 ]; then
+        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher-2.git /home/${user}/nix-pypi-fetcher-2
+        cd /home/${user}/nix-pypi-fetcher-2
         git config user.email "$EMAIL"
         git config user.name "DavHau"
       fi
-      cd /home/${user}/nix-pypi-fetcher
+      cd /home/${user}/nix-pypi-fetcher-2
       #git checkout wheels
       #git pull
       ${python}/bin/python -u ${src}/wheel_deps_spider.py
@@ -65,19 +65,19 @@ in
       WORKERS = "100";
       PYTHONPATH = src;
       EMAIL = "hsngrmpf+pypidepscrawler@gmail.com";
-      pypi_fetcher = "/home/${user}/nix-pypi-fetcher";
+      pypi_fetcher = "/home/${user}/nix-pypi-fetcher-2";
       dump_dir = "/home/${user}/wheels";
       skip = "40";
     };
     path = [ python pkgs.git ];
     script = ''
-      if [ ! -e /home/${user}/nix-pypi-fetcher ]; then
-        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher.git /home/${user}/nix-pypi-fetcher
-        cd /home/${user}/nix-pypi-fetcher
+      if [ ! -e /home/${user}/nix-pypi-fetcher-2 ]; then
+        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher-2.git /home/${user}/nix-pypi-fetcher-2
+        cd /home/${user}/nix-pypi-fetcher-2
         git config user.email "$EMAIL"
         git config user.name "DavHau"
       fi
-      cd /home/${user}/nix-pypi-fetcher
+      cd /home/${user}/nix-pypi-fetcher-2
       #git checkout wheels
       #git pull
       ${python}/bin/python -u ${src}/wheel_deps_spider.py
@@ -92,19 +92,19 @@ in
       WORKERS = "100";
       PYTHONPATH = src;
       EMAIL = "hsngrmpf+pypidepscrawler@gmail.com";
-      pypi_fetcher = "/home/${user}/nix-pypi-fetcher";
+      pypi_fetcher = "/home/${user}/nix-pypi-fetcher-2";
       dump_dir = "/home/${user}/wheels";
       skip = "80";
     };
     path = [ python pkgs.git ];
     script = ''
-      if [ ! -e /home/${user}/nix-pypi-fetcher ]; then
-        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher.git /home/${user}/nix-pypi-fetcher
-        cd /home/${user}/nix-pypi-fetcher
+      if [ ! -e /home/${user}/nix-pypi-fetcher-2 ]; then
+        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher-2.git /home/${user}/nix-pypi-fetcher-2
+        cd /home/${user}/nix-pypi-fetcher-2
         git config user.email "$EMAIL"
         git config user.name "DavHau"
       fi
-      cd /home/${user}/nix-pypi-fetcher
+      cd /home/${user}/nix-pypi-fetcher-2
       #git checkout wheels
       #git pull
       ${python}/bin/python -u ${src}/wheel_deps_spider.py
@@ -119,19 +119,19 @@ in
       WORKERS = "100";
       PYTHONPATH = src;
       EMAIL = "hsngrmpf+pypidepscrawler@gmail.com";
-      pypi_fetcher = "/home/${user}/nix-pypi-fetcher";
+      pypi_fetcher = "/home/${user}/nix-pypi-fetcher-2";
       dump_dir = "/home/${user}/wheels";
       skip = "c0";
     };
     path = [ python pkgs.git ];
     script = ''
-      if [ ! -e /home/${user}/nix-pypi-fetcher ]; then
-        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher.git /home/${user}/nix-pypi-fetcher
-        cd /home/${user}/nix-pypi-fetcher
+      if [ ! -e /home/${user}/nix-pypi-fetcher-2 ]; then
+        git clone --single-branch --branch wheels https://github.com/DavHau/nix-pypi-fetcher-2.git /home/${user}/nix-pypi-fetcher-2
+        cd /home/${user}/nix-pypi-fetcher-2
         git config user.email "$EMAIL"
         git config user.name "DavHau"
       fi
-      cd /home/${user}/nix-pypi-fetcher
+      cd /home/${user}/nix-pypi-fetcher-2
       #git checkout wheels
       #git pull
       ${python}/bin/python -u ${src}/wheel_deps_spider.py

--- a/pypi-crawlers/src/crawl_sdist_deps.py
+++ b/pypi-crawlers/src/crawl_sdist_deps.py
@@ -191,7 +191,7 @@ def cleanup():
 
 def ensure_pypi_fetcher(dir):
     if not os.path.isdir(dir):
-        cmd = f'git clone git@github.com:DavHau/nix-pypi-fetcher.git {dir}'
+        cmd = f'git clone git@github.com:DavHau/nix-pypi-fetcher-2.git {dir}'
         sp.check_call(cmd, shell=True)
     sp.check_call("git checkout master && git pull", shell=True, cwd=dir)
 


### PR DESCRIPTION
Fixes #535 

All I did was find all occurrences of nix-pypi-fetcher and replace them with nix-pypi-fetcher-2.  I don't really understand all of the interactions with this value (I'm particularly unclear on the git revisions that appear some of these values - why can't I find them on github and why can I change the repository without changing the revision?)

The result appears to work.  With HEAD of this branch and pypi-deps-db 5440c9c76f6431f300fb6a1ecae762a5444de5f6 I can build tahoe-lafs/tahoe-lafs ~af10f96ef729b12dcbacdc0b5dd7f4750ff0b942~ 96d783534a986e2bca9ef5a00e99240aa2232c88 whereas with mach-nix 68a85753555ed67ff53f0d0320e5ac3c725c7400 and pypi-deps-db 5440c9c76f6431f300fb6a1ecae762a5444de5f6 I get the error in the referenced ticket.
