### PR TITLE
Update pypi-deps-db version

### DIFF
--- a/mach_nix/flake.lock
+++ b/mach_nix/flake.lock
@@ -33,11 +33,11 @@
     "pypi-deps-db": {
       "flake": false,
       "locked": {
-        "lastModified": 1661155889,
-        "narHash": "sha256-t00mBTZhmZBT4jteO6pJbU0wyRS6/ep4pKmQNeztEms=",
+        "lastModified": 1678051695,
+        "narHash": "sha256-kFFP8TN8pEKARtjK9loGdH+TU23ZbHdVLCUdNcufKPs=",
         "owner": "DavHau",
         "repo": "pypi-deps-db",
-        "rev": "49c620f3de2b557c9d5c44f58a00fee59f27d1b0",
+        "rev": "e00b22ead9d3534ba1c448e1af3076af6b234acf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
It seems the old flake dependency to `pypi-deps-db` is too old, and refers to a now non-existent commit of `nix-pypi-fetcher-2`. 

Therefore, trying to build any python package using the `wheel` provider will fail with:
```
       at /nix/store/hqqb9ddw62wwm8sx3splqgzwpcvrcyai-mach_nix_file/share/mach_nix_file.nix:11:17:

           10|   };
           11|   pypiFetcher = import pypi_fetcher_src { inherit pkgs; };
             |                 ^
           12|   fetchPypi = pypiFetcher.fetchPypi;

       error: unable to download 'https://github.com/DavHau/nix-pypi-fetcher-2/tarball/d93c6f30f09599e9df96b6cd345f47ce7c172136': HTTP error 404

       response body:

       404: Not Found
```

Updating that dependency seems to fix this. 