### PR TITLE
Add deepspeed-mii.remove-asyncio to fixes

### DIFF
--- a/mach_nix/fixes.nix
+++ b/mach_nix/fixes.nix
@@ -129,4 +129,11 @@ rec {
     patchPhase = "";
   };
 
+  deepspeed-mii.remove-asyncio = {
+    _cond = ({ pyver, ... }:
+      # asyncio becomes a built-in library since Python 3.4
+      comp_ver pyver ">=" "3.4");
+    propagatedBuildInputs.mod =
+      builtins.filter (input: input.pname != "asyncio");
+  };
 }

--- a/mach_nix/nix/lib.nix
+++ b/mach_nix/nix/lib.nix
@@ -193,7 +193,7 @@ rec {
     let
       provider = if hasAttr "provider" oa.passthru then oa.passthru.provider else "nixpkgs";
     in
-      condition { prov = provider; ver = oa.version; pyver = oa.pythonModule.version; };
+      condition { prov = provider; ver = oa.version; pyver = oa.passthru.pythonModule.version; };
 
     extract = python: src: fail_msg:
     let


### PR DESCRIPTION
`asyncio` becomes a built-in Python library since Python 3.4. The old `asyncio` package is incompatible with Python 3.7. See https://stackoverflow.com/questions/51196568/create-task-asyncio-async-syntaxerror-invalid-syntax