### PR TITLE
Add setuptools dependency for distlib

### DIFF
--- a/mach_nix/nix/python-deps.nix
+++ b/mach_nix/nix/python-deps.nix
@@ -3,12 +3,14 @@ rec {
   distlib = python.pkgs.buildPythonPackage {
     name = "distlib-0.3.7.dev.0";
     src = fetchurl {
-      # PR fixing python_full_version: https://github.com/pypa/distlib/pull/187
-      url = "https://github.com/pypa/distlib/archive/61534987ec5e4b3bdd346de8ffcc7aeaeb132572.zip";
-      sha256 = "0mrp73k6nh3cphbamsv9k330irz5xnzays6d66w6xf857xj1gfx1";
+      url = "https://github.com/pypa/distlib/archive/05375908c1b2d6b0e74bdeb574569d3609db9f56.zip";
+      sha256 = "qbaJlmAkp5V8l1bWzJFar+6GiRiUyNMJAW6Yi1xZ088=";
     };
     format = "pyproject";
     doCheck = false;
+    propagatedBuildInputs = [
+      setuptools
+    ];
   };
   resolvelib = python.pkgs.buildPythonPackage {
     name = "resolvelib-0.8.1";


### PR DESCRIPTION
This PR added the `setuptools` dependency for `distlib` because newer `nixpkgs` does not provide `setuptools` for Python libraries by default