### PR TITLE
Add Rich exceptions including locals with rich.traceback

### DIFF
--- a/mach_nix/generate.py
+++ b/mach_nix/generate.py
@@ -5,6 +5,9 @@ from os.path import dirname
 from pprint import pformat
 from typing import List
 
+import rich.traceback
+rich.traceback.install(show_locals=True)
+
 from resolvelib import ResolutionImpossible
 from resolvelib.resolvers import RequirementInformation
 

--- a/mach_nix/nix/python-deps.nix
+++ b/mach_nix/nix/python-deps.nix
@@ -29,6 +29,8 @@ rec {
     doCheck = false;
   };
 
+
+  rich = python.pkgs.rich;
   networkx = python.pkgs.networkx;
   packaging = python.pkgs.packaging;
   setuptools = python.pkgs.setuptools;

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'resolvelib == 0.8.1',
         'toml',
         'tree-format == 0.1.2',
-        'rich==12.4.1',
+        'rich',
     ],
     tests_require=test_deps,
     extras_require=extras,

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'resolvelib == 0.8.1',
         'toml',
         'tree-format == 0.1.2',
+        'rich==12.4.1',
     ],
     tests_require=test_deps,
     extras_require=extras,


### PR DESCRIPTION
This makes mach-nix python exceptions look like this,
capturing locals at every part of the stack,
hopefully helping with the postmortem debug-ability.

![image](https://github.com/DavHau/mach-nix/assets/1257580/fbe15950-e41a-44f2-950f-daf518d47432)

Note that rich is already in the nixpkgs mach-nix uses.