### PR TITLE
Bug 549

### DIFF
--- a/mach_nix/data/nixpkgs.py
+++ b/mach_nix/data/nixpkgs.py
@@ -2,6 +2,7 @@ import json
 from collections import UserDict
 from dataclasses import dataclass
 from typing import List
+import packaging.version
 
 from mach_nix.cache import cached
 from mach_nix.versions import parse_ver, Version
@@ -29,7 +30,11 @@ class NixpkgsIndex(UserDict):
             if nix_data is None:
                 continue
             pname = nix_data["pname"]
-            version = parse_ver(nix_data["version"])
+            try:
+                version = parse_ver(nix_data["version"])
+            except packaging.version.InvalidVersion as e:
+                print("omitting nixpkgs / ", pname, " version was invalid: '", nix_data["version"], "'", sep="")
+                continue
             pname_key = pname.replace("_", "-").lower()
             if pname_key not in self.data:
                 self.data[pname_key] = {}

--- a/mach_nix/requirements.py
+++ b/mach_nix/requirements.py
@@ -189,11 +189,10 @@ def parse_reqs_line(line):
 
     return name, extras, all_specs, build, marker
 
-
 @cached(keyfunc=lambda args: hash((tuple(args[0]), args[1])))
 def filter_versions(
         versions: List[Version],
-        req: Requirement):
+        req: Requirement) -> List[Version]:
     """
     Reduces a given list of versions to contain only versions
     which are allowed according to the given specifiers
@@ -202,7 +201,7 @@ def filter_versions(
     if not req.specs:
         # We filter version with an empty specifier set, since that will filter
         # out prerelease, if there are any other releases.
-        return SpecifierSet().filter(versions)
+        return list(SpecifierSet().filter(versions)) # return a list in both cases
     matched_versions = []
     for specs in req.specs:
         matched_versions.extend(


### PR DESCRIPTION
This tackles #549 by throwing out all nixpkgs python-packages with invalid versions (ie. everything with unstable-yyyy-mm-dd (~86 packages in 23.05).

It also tackles a bug in the resolve lib adapter, which sometimes would only return a list, and sometimes a list_iterator, which lead to psutil:5.49 not being accepted for the requirement 'psutil'.