### PR TITLE
Fix infinite recursion when pip/setuptools is involved

### DIFF
--- a/mach_nix/data/nixpkgs.py
+++ b/mach_nix/data/nixpkgs.py
@@ -2,6 +2,7 @@ import json
 from collections import UserDict
 from dataclasses import dataclass
 from typing import List
+import packaging.version
 
 from mach_nix.cache import cached
 from mach_nix.versions import parse_ver, Version
@@ -29,7 +30,11 @@ class NixpkgsIndex(UserDict):
             if nix_data is None:
                 continue
             pname = nix_data["pname"]
-            version = parse_ver(nix_data["version"])
+            try:
+                version = parse_ver(nix_data["version"])
+            except packaging.version.InvalidVersion as e:
+                print("omitting nixpkgs / ", pname, " version was invalid: '", nix_data["version"], "'", sep="")
+                continue
             pname_key = pname.replace("_", "-").lower()
             if pname_key not in self.data:
                 self.data[pname_key] = {}

--- a/mach_nix/generators/overides_generator.py
+++ b/mach_nix/generators/overides_generator.py
@@ -194,6 +194,8 @@ class OverridesGenerator(ExpressionGenerator):
     def _gen_overrideAttrs(
             self, name, ver, circular_deps, nix_name, provider, build_inputs_str, prop_build_inputs_str,
             keep_src=False):
+        if name == 'setuptools' or name == "pip":
+            return ""
         out = f"""
             "{name}" = override python-super."{nix_name}" ( oldAttrs:
               # filter out unwanted dependencies and replace colliding packages

--- a/mach_nix/requirements.py
+++ b/mach_nix/requirements.py
@@ -189,11 +189,10 @@ def parse_reqs_line(line):
 
     return name, extras, all_specs, build, marker
 
-
 @cached(keyfunc=lambda args: hash((tuple(args[0]), args[1])))
 def filter_versions(
         versions: List[Version],
-        req: Requirement):
+        req: Requirement) -> List[Version]:
     """
     Reduces a given list of versions to contain only versions
     which are allowed according to the given specifiers
@@ -202,7 +201,7 @@ def filter_versions(
     if not req.specs:
         # We filter version with an empty specifier set, since that will filter
         # out prerelease, if there are any other releases.
-        return SpecifierSet().filter(versions)
+        return list(SpecifierSet().filter(versions)) # return a list in both cases
     matched_versions = []
     for specs in req.specs:
         matched_versions.extend(


### PR DESCRIPTION
This fixes #529, by not writing out the overrides for setuptools & pip in mach_nix-file.nix.

I feel rather unsure about this fix, guidance would be nice :).