### PR TITLE
WIP: extraction of requirements for pyproject.toml projects 

### DIFF
--- a/lib/extractor/pyproject_toml_parser.py
+++ b/lib/extractor/pyproject_toml_parser.py
@@ -1,0 +1,132 @@
+# requirements extractor for pyproject.toml  projects (Poetry, flint, pep621).
+import os
+import toml
+import json
+
+
+# Load the pyproject.toml file
+with open("pyproject.toml", "r") as file:
+    pyproject = toml.load(file)
+    print("pyproject.toml loaded")
+    import pprint
+
+    pprint.pprint(pyproject)
+
+
+def parse_to_setup_requirements(key, value):
+    """We need to turn ^ requirements into >= and < requirements"""
+    if "^" in value:
+        major_version = int(value.split(".")[0].replace("^", ""))
+        if major_version > 0:
+            next_major_version = str(major_version + 1)
+            return f'{key}>={value.replace("^", "")},<{next_major_version}.0.0'
+        else:
+            # when it's ^0.x, we need ^0.(x+10).0
+            minor_version = int(value.split(".")[1].replace("^", ""))
+            next_minor_version = str(minor_version + 1)
+            return f'{key}>={value.replace("^", "")},<0.{next_minor_version}.0'
+
+    else:
+        return f"{key}{value}"
+
+
+def parse_req_from_str(key_value):
+    if "^" in key_value:
+        pkg, version = key_value.split("^")
+        return parse_to_setup_requirements(pkg, "^" + version)
+    else:
+        return key_value
+
+
+def parse_poetry(pyproject):
+    dependencies = {}
+    dependencies["name"] = pyproject["tool"]["poetry"]["name"]
+    dependencies["version"] = pyproject["tool"]["poetry"]["version"]
+    dependencies["install_requires"] = []
+    for key, value in pyproject["tool"]["poetry"]["dependencies"].items():
+        if key == "python":
+            dependencies["python_requires"] = value.replace("^", ">=")
+        else:
+            dependencies["install_requires"].append(
+                parse_to_setup_requirements(key, value)
+            )
+
+    dependencies["extras_require"] = {}
+    for key, value in pyproject["tool"]["poetry"]["dev-dependencies"].items():
+        dependencies["extras_require"].setdefault("dev", []).append(f"{key}")
+    return dependencies
+
+
+def parse_flit(pyproject):
+    dependencies = {}
+    # Parse the dependencies into the desired format
+    metadata = pyproject["tool"]["flit"]["metadata"]
+    dependencies["name"] = metadata.get("module")
+    dependencies["version"] = ""  # Flit doesn't have a version field in pyproject.toml
+    if "requires-python" in metadata:
+        dependencies["python_requires"] = metadata.get("requires-python", "")
+
+    dependencies["install_requires"] = []
+
+    if "requires" in metadata:
+        for requirement in metadata["requires"]:
+            dependencies["install_requires"].append(parse_req_from_str(requirement))
+
+    dependencies["extras_require"] = {}
+    if "dev-requires" in metadata:
+        for key, value in metadata["dev-requires"].items():
+            dependencies["extras_require"].setdefault("dev", []).append(
+                parse_to_setup_requirements(key, value)
+            )
+    return dependencies
+
+
+def parse_pep621(pyproject):
+    # Parse the dependencies into the desired format
+    project = pyproject["project"]
+    dependencies = {
+        "name": project.get("name"),
+        "version": project.get("version"),
+        "python_requires": project.get("requires-python", ""),
+        "install_requires": [],
+        "extras_require": {},
+    }
+    if "dependencies" in project:
+        for key_value in project["dependencies"]:
+            dependencies["install_requires"].append(parse_req_from_str(key_value))
+    if "optional-dependencies" in project:
+        for key, values in project["optional-dependencies"].items():
+            dependencies["extras_require"][key] = []
+            for pkg_version in values:
+                dependencies["extras_require"][key].append(
+                    parse_req_from_str(pkg_version)
+                )
+    return dependencies
+
+
+if pyproject.get("project", None):
+    print("detected pep 621 format project")
+    dependencies = parse_pep621(pyproject)
+elif pyproject.get("tool", {}).get("poetry", None):
+    print("detected poetry format project")
+    dependencies = parse_poetry(pyproject)
+elif pyproject.get("tool", {}).get("flit", None):
+    print("detected flit format project")
+    dependencies = parse_flit(pyproject)
+else:
+    print(
+        "No supported requirements specification in pyproject.toml. Currently only pep621, flit and poetry are supported."
+        " Though of course this might just mean your package has no requirements."
+    )
+    dependencies = {}
+
+if "build-system" in pyproject:
+    dependencies["setup_requires"] = [
+        parse_req_from_str(key_value)
+        for key_value in pyproject["build-system"].get("requires", [])
+    ]
+
+out_file = os.environ.get("out_file", "python.json")
+with open(out_file, "w") as file:
+    print(f"storing dependencies in {out_file}")
+    json.dump(dependencies, file, indent=2)

--- a/mach_nix/nix/buildPythonPackage.nix
+++ b/mach_nix/nix/buildPythonPackage.nix
@@ -24,7 +24,7 @@ let
       _fixes ? import ../fixes.nix {pkgs = pkgs;},
       ...
     }:
-    with (_buildPythonParseArgs args);
+    # with (_buildPythonParseArgs args);
     with builtins;
     let
       python_pkg = l.selectPythonPkg pkgs python requirements;
@@ -54,13 +54,23 @@ let
             in
               output_version
               );
-      meta_reqs = l.extract_requirements python_pkg src "${pname}:${version}" extras;
+              meta_reqs = 
+              let format = (if builtins.hasAttr "format" args then args.format else "setuptools");
+              in
+
+              l.extract_requirements {
+                python = python_pkg;
+                src = src;
+                name = "${pname}:${version}";
+                extras = extras;
+                format = format;
+              };
       reqs =
         (if requirements == "" then
-          if builtins.hasAttr "format" args && args.format != "setuptools" then
-            throw "Automatic dependency extraction is only available for 'setuptools' format."
-                  " Please specify 'requirements' if setuptools is not used."
-          else
+          # if builtins.hasAttr "format" args && args.format != "setuptools" && args.format != "pyproject" then
+          #   throw "Automatic dependency extraction is only available for 'setuptools' and 'pyproject' formats."
+          #         " Please specify 'requirements' if something else is used."
+          # else
             meta_reqs
         else
           requirements)


### PR DESCRIPTION
This is a WIP PR to finally get automated extraction of pyproject.toml projects.

Right now it's got two weaknesses:
- no tests (I have to do a deep dive into understanding how mach-nix is tested in the first place)
- and support only for the 'script_single' case of the requirements extractor - I'm not yet certain when the 'script' case (which seems to handle multiple python versions?) is being called.

Once I got pypy-debs-db running again, I'll see if I can stick the extractor in that, that should give us a better picture with regards on what it can and can't read.