### PR TITLE
Invalid versions outside nixpkgs

### DIFF
--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -128,6 +128,7 @@ let
     mkdir $out
     echo "extracting dependencies"
     SETUPTOOLS_USE_DISTUTILS=stdlib out_file=$out/python.json ${py}/bin/python -c "${setuptools_shim}" install &> $out/python.log || true
+    cat $out/python.log
   '';
   base_derivation = pyVersions: with pkgs; {
     buildInputs = [ unzip pkg-config ];


### PR DESCRIPTION
Following #564, it was discovered that pypi is also full of no longer parsing versions.
We had 'fixed' this for nixpkgs in #549 by eliminating all non-parsable versions,
this does the same for pypi (sdist & wheel) and conda.

It's a hot take, and not the best way forward I suppose, but it does make master usable for now.