### PR TITLE
Rename store paths for package-requirements-from-source

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
                   in (import ./lib/extractor {}).extract_from_src {
                     py="python3";
                     src = srcTar;
+                    name = "mach-nix";
                   }'
                 cat reqs/*
                 rm reqs

--- a/lib/extractor/default.nix
+++ b/lib/extractor/default.nix
@@ -161,13 +161,13 @@ with pkgs;
 rec {
   inherit machnix_source mkPy pythonInterpreters;
   example = extractor {pkg = "requests"; version = "2.22.0";};
-  extract_from_src = {py, src}:
+  extract_from_src = {py, src, name}:
     let
       py' = if isString py then pkgs."${py}" else py;
     in
     stdenv.mkDerivation ( (base_derivation []) // {
       inherit src;
-      name = "package-requirements";
+      name = "${name}-mach-nix-requirements";
       installPhase = script_single (mkPy py');
     });
   extractor = {pkg, version, ...}:

--- a/mach_nix/nix/buildPythonPackage.nix
+++ b/mach_nix/nix/buildPythonPackage.nix
@@ -54,7 +54,7 @@ let
             in
               output_version
               );
-      meta_reqs = l.extract_requirements python_pkg src "${pname}:${version}" extras;
+      meta_reqs = l.extract_requirements python_pkg src "${pname}-${version}" extras;
       reqs =
         (if requirements == "" then
           if builtins.hasAttr "format" args && args.format != "setuptools" then


### PR DESCRIPTION
Another tiny quality-of-debuggers-life-improvement:

Previously, all source-extracted package requirements were stored in /nix/store/${hash}-package-requirements.

This patch fits the name (which is name-version, actually) into those path names,
and names them' ${name}-mach-nix-requirements'